### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ff748a82a5fff004c952f32eacd64604a6f4036f",
-        "sha256": "0a6nidbzdmywxfknqgj7hjhdsvvxncb8jkksyc49mp81d9lwk2fy",
+        "rev": "5fe7b30633fcdc5cca2b7a1f5459b71c66ca6b88",
+        "sha256": "1bz7qf57vmz5jrky4zc868xpjgjln3mbrx1h6whji5xb3kb0fwd9",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/ff748a82a5fff004c952f32eacd64604a6f4036f.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5fe7b30633fcdc5cca2b7a1f5459b71c66ca6b88.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                            |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`93d5531b`](https://github.com/NixOS/nixpkgs/commit/93d5531b29a9464033b5742dc988dfa4a9413699) | `macchina: 1.1.3 -> 1.1.4`                                |
| [`f8cea6b5`](https://github.com/NixOS/nixpkgs/commit/f8cea6b5bc823b5e416fc4f615c97b57f14ac942) | `treefmt: 0.2.5 -> 0.2.6 (#137951)`                       |
| [`c6574c86`](https://github.com/NixOS/nixpkgs/commit/c6574c8664d39f6eede326d8348d21cbe1fd3f97) | `khronos: clarify license`                                |
| [`52e9be9a`](https://github.com/NixOS/nixpkgs/commit/52e9be9ada16376c5d9ff981be68715cdd195d52) | `goreleaser: 0.176.0 -> 0.179.0`                          |
| [`ddbbf5d8`](https://github.com/NixOS/nixpkgs/commit/ddbbf5d80bcee06ff62b0fb53d926e9c8b1174d6) | `coqPackages.parsec: init at 0.1.0`                       |
| [`28bf99d3`](https://github.com/NixOS/nixpkgs/commit/28bf99d3cf2b42e03b5e5507b7ae3d8c487881fd) | `coqPackages.ceres: init at 0.4.0`                        |
| [`88531b67`](https://github.com/NixOS/nixpkgs/commit/88531b67a2a5f969c4803b37a66c7d6303fdc6b9) | `python38Packages.node-semver: 0.7.0 -> 0.8.1`            |
| [`7ac53ad7`](https://github.com/NixOS/nixpkgs/commit/7ac53ad7b954c1b349d4172c38767e8e77ac4640) | `ocamlPackages.mdx: 1.10.1 -> 1.11.0`                     |
| [`0b93a433`](https://github.com/NixOS/nixpkgs/commit/0b93a433c456404ab9e5b033fdea912789cd1ae3) | `python38Packages.snowflake-sqlalchemy: 1.3.1 -> 1.3.2`   |
| [`8a7a1b06`](https://github.com/NixOS/nixpkgs/commit/8a7a1b06bac0025919eb92ea8ea671932feb8274) | `python38Packages.pg8000: 1.21.1 -> 1.21.2`               |
| [`b7eb0b99`](https://github.com/NixOS/nixpkgs/commit/b7eb0b990b054146a7f6280725c08add4257642b) | `esbuild: 0.12.27 -> 0.12.28`                             |
| [`a293c865`](https://github.com/NixOS/nixpkgs/commit/a293c865425287c3098da223495bb77233c789f8) | `python38Packages.pex: 2.1.49 -> 2.1.50`                  |
| [`2de65a80`](https://github.com/NixOS/nixpkgs/commit/2de65a8061cc23589cc4329079a9ef79ac030c6b) | `electrs: 0.8.10 -> 0.8.11`                               |
| [`2742598f`](https://github.com/NixOS/nixpkgs/commit/2742598f99872df6be44082f12421acb27677a89) | `ocamlPackages.parany: 12.0.3 -> 12.1.1`                  |
| [`443fa7db`](https://github.com/NixOS/nixpkgs/commit/443fa7dbd5b37044b6a4facd87991c9d1b8c951e) | `cointop: 1.6.6 -> 1.6.8`                                 |
| [`898bc910`](https://github.com/NixOS/nixpkgs/commit/898bc910e86123e2c5ab86d15264378ef1edf4e5) | `cmark-gfm: 0.29.0.gfm.0 -> 0.29.0.gfm.1`                 |
| [`30df428d`](https://github.com/NixOS/nixpkgs/commit/30df428d7e7b7f92b1000689921f5e82aa064439) | `cloudflared: 2021.8.7 -> 2021.9.0`                       |
| [`f840898e`](https://github.com/NixOS/nixpkgs/commit/f840898e8530ff44625b00b418072e52c97b426c) | `python38Packages.google-cloud-firestore: 2.3.1 -> 2.3.2` |
| [`fe034d33`](https://github.com/NixOS/nixpkgs/commit/fe034d33be5ccf3efc850a6021a1ab41cf5831d1) | `nixos/gitlab: Enable roation of log files`               |
| [`f27bedec`](https://github.com/NixOS/nixpkgs/commit/f27bedec56dc32ba4253ae05434a1a46156010a9) | `python38Packages.dataclasses-json: 0.5.5 -> 0.5.6`       |
| [`1172c99c`](https://github.com/NixOS/nixpkgs/commit/1172c99c506ed4c3c7c8f47d3b51fb195eca5d96) | `nlohmann_json: enable checkPhase`                        |
| [`8465eb74`](https://github.com/NixOS/nixpkgs/commit/8465eb7493d949c3a8020e814d2f8a5fca08137d) | `vscx/ms-vsliveshare-vsliveshare: 1.0.4673 -> 1.0.4836`   |
| [`2ecd21c1`](https://github.com/NixOS/nixpkgs/commit/2ecd21c1cce634960584c6310b7cca158962e98e) | `thicket: 0.1.4 -> 0.1.5`                                 |
| [`f7a04bdd`](https://github.com/NixOS/nixpkgs/commit/f7a04bddd8e7c28936e314f55f1302ca68506aba) | `telescope: 0.5.1 -> 0.5.2`                               |
| [`40d83a9a`](https://github.com/NixOS/nixpkgs/commit/40d83a9a2159809d2d47fc6598665c184578f1cf) | `electron_12: 12.1.0 -> 12.1.1`                           |
| [`3f26111f`](https://github.com/NixOS/nixpkgs/commit/3f26111fb81f4d8ee2d28816b632935564b293bc) | `electron_13: 13.3.0 -> 13.4.0`                           |
| [`304dffb1`](https://github.com/NixOS/nixpkgs/commit/304dffb16092a017d88a1577fbe304bea5e73375) | `electron_14: 14.0.0 -> 14.0.1`                           |
| [`d1f3ce25`](https://github.com/NixOS/nixpkgs/commit/d1f3ce25cb71ece73de8a067d97fd71f29ffa362) | `khronos: 1.0.8 -> 3.5.9`                                 |
| [`268c8d77`](https://github.com/NixOS/nixpkgs/commit/268c8d77ca7302dd8c72370532e5158a0a3e4a2e) | `vscode: 1.60.0 -> 1.60.1`                                |
| [`313e03f4`](https://github.com/NixOS/nixpkgs/commit/313e03f4fb55ef46f6474fba981f8d25bb7b0ea8) | `spaceship-prompt: 3.14.0 -> 3.14.1`                      |
| [`d37f5847`](https://github.com/NixOS/nixpkgs/commit/d37f5847d3a536fe00b144b84858ffe8de6dd956) | `rtsp-simple-server: 0.17.2 -> 0.17.3`                    |
| [`1c9cbe8a`](https://github.com/NixOS/nixpkgs/commit/1c9cbe8a05567e918c3b12941569a7e63d54e539) | `opensmt: 2.1.0 -> 2.1.1`                                 |
| [`b471773d`](https://github.com/NixOS/nixpkgs/commit/b471773d5749365f01cb89079d476b34c58ddce6) | `python3Packages.aioesphomeapi: 9.0.0 -> 9.1.0`           |
| [`f3aeba71`](https://github.com/NixOS/nixpkgs/commit/f3aeba71a3381672dfe60ef34c561605bd2afd7a) | `python38Packages.xmlsec: 1.3.11 -> 1.3.12`               |
| [`d9d3ea62`](https://github.com/NixOS/nixpkgs/commit/d9d3ea6278a78a657c772784f92f404e0bfd1b20) | `gnome.file-roller: avoid wrapping the program twice`     |
| [`2dcab2aa`](https://github.com/NixOS/nixpkgs/commit/2dcab2aa335b91ad761f0dfb5e03007ea5432c38) | `python38Packages.pytest-snapshot: 0.6.1 -> 0.6.3`        |
| [`cd641476`](https://github.com/NixOS/nixpkgs/commit/cd641476cfcf8d5494e661debac9a3fe40f4cf32) | `github-runner: 2.281.1 -> 2.282.0`                       |
| [`0242a364`](https://github.com/NixOS/nixpkgs/commit/0242a3641bc783d2fcd8009cfd1b300f40b3bd1a) | `libsForQt5.qtutilities: 6.3.3 -> 6.5.0`                  |
| [`82652bcc`](https://github.com/NixOS/nixpkgs/commit/82652bcc2c7440ee4432975fbb9e0ac8b0ea3551) | `cpp-utilities: 5.11.0 -> 5.11.1`                         |
| [`919a4ab5`](https://github.com/NixOS/nixpkgs/commit/919a4ab53750f4108a5476ecf03f8886ef52200a) | `tts: 0.2.2 -> 0.3.0`                                     |
| [`451f4f9f`](https://github.com/NixOS/nixpkgs/commit/451f4f9f5c6c05a4fd1b1d89032eb8e07dd02b9f) | `python38Packages.coqpit: 0.0.13 -> 0.0.14`               |
| [`e8bbcc79`](https://github.com/NixOS/nixpkgs/commit/e8bbcc79fd07014b146835dfd7f5eba2079d9a55) | `github-runner: prevent self-updates`                     |
| [`cc5c902f`](https://github.com/NixOS/nixpkgs/commit/cc5c902fdf94b798c3b68e55ebb7e1a1185113a1) | `github-runner: use dummy SHA-1 as `GitInfoCommitHash``   |
| [`f76136e1`](https://github.com/NixOS/nixpkgs/commit/f76136e109acdcd5b64451a08b478e13bd5e19a4) | `gnunet: 0.15.0 -> 0.15.3`                                |
| [`18bd2282`](https://github.com/NixOS/nixpkgs/commit/18bd22822c1054b74d165597ee504cece999cec8) | `nlohmann_json: update meta information`                  |
| [`13af44ba`](https://github.com/NixOS/nixpkgs/commit/13af44ba2a0fd6a4ef8efbb6a8007e5e4f45e6e3) | `ecl: fix nativeBuildInputs`                              |
| [`d9f78e95`](https://github.com/NixOS/nixpkgs/commit/d9f78e95bad026c5232f534fdb236b46c3ea8b1a) | `nlohmann_json: 3.9.1 -> 3.10.2`                          |
| [`dc2002ce`](https://github.com/NixOS/nixpkgs/commit/dc2002ce44fd6a19f7575540c09380b362c81a8d) | `atlassian-jira: 8.16.1 -> 8.19`                          |
| [`76f50735`](https://github.com/NixOS/nixpkgs/commit/76f507357347e41de512039e189e5016edcaa2bb) | `pythonPackages.fastjet: init`                            |
| [`0ec2acf5`](https://github.com/NixOS/nixpkgs/commit/0ec2acf51f2f6e7dabc64ad03c92b2391d604c44) | `root: build with -Dimt=ON`                               |
| [`95b2d74b`](https://github.com/NixOS/nixpkgs/commit/95b2d74bc53621460e651d53e0d7de3ec8411fc5) | `root: re-enable unvendored LLVM`                         |
| [`aedfb59c`](https://github.com/NixOS/nixpkgs/commit/aedfb59c87eccee02b873d46953c4bdc5bf37815) | `root: 6.24.02 -> 6.24.06`                                |
| [`7b2b2771`](https://github.com/NixOS/nixpkgs/commit/7b2b277105e581f4a42c3f108de232c5bde3c344) | `teamspeak_client: fix desktop icon`                      |
| [`249cc6f9`](https://github.com/NixOS/nixpkgs/commit/249cc6f92f3842b519e3c0ccab6c011da4008841) | `fastjet: 3.3.4 -> 3.4.0`                                 |
| [`ef7cb070`](https://github.com/NixOS/nixpkgs/commit/ef7cb07023e2bfae721d656acd3052d154b7f8ca) | `radicle-upstream: 0.2.9 -> 0.2.10`                       |
| [`8152b272`](https://github.com/NixOS/nixpkgs/commit/8152b2725306104d42864ae5c303526a48b7e1ef) | `conftest: fix tests`                                     |
| [`9c8f6efc`](https://github.com/NixOS/nixpkgs/commit/9c8f6efc550a04213236c308bc2f88d176527efa) | `xfitter: enable WITH_YAML support on darwin`             |
| [`b0f07a16`](https://github.com/NixOS/nixpkgs/commit/b0f07a1695cfe9f0383ecd90acd9250ec0f33e59) | `tintin: fix on darwin`                                   |
| [`e3ba3411`](https://github.com/NixOS/nixpkgs/commit/e3ba3411c5c67453c0e999dbb222b5319691b612) | `memorymapping: init at unstable-2014-02-20`              |
| [`8b2abe42`](https://github.com/NixOS/nixpkgs/commit/8b2abe429d30a23ffb58a02fd7abddd87e22d154) | `hyx: use memstreamHook`                                  |
| [`66f3da43`](https://github.com/NixOS/nixpkgs/commit/66f3da43f9bfca0665cab691384c1a0902aa84b2) | `memstream: init at 0.1`                                  |
| [`784c5795`](https://github.com/NixOS/nixpkgs/commit/784c5795c0096778974dbafdfacd845b27a16bc2) | `xmrig: 6.14.0 -> 6.14.1`                                 |
| [`ff9df147`](https://github.com/NixOS/nixpkgs/commit/ff9df147c99f32353fbbcb787c52c05d8f964f5d) | `nixos/gdm: remove udev-settle dependency`                |