### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bfc38d3d0d22c528e8abc46c5dd5f3f50fc4554b",
-        "sha256": "0hfxz9gnk6cjaa90halmw2334g6233izdw77li1jnv51m93miw57",
+        "rev": "abc00fd6bd7d81af4b86a1f2dc88432326dc9021",
+        "sha256": "1mini17flxsahqvanf24s49w1mqkl7xawh0ssc8fzh1z1d6valiq",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/bfc38d3d0d22c528e8abc46c5dd5f3f50fc4554b.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/abc00fd6bd7d81af4b86a1f2dc88432326dc9021.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                       |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`abc00fd6`](https://github.com/NixOS/nixpkgs/commit/abc00fd6bd7d81af4b86a1f2dc88432326dc9021) | `buildah: 1.22.3 -> 1.23.0`                                          |
| [`d4640395`](https://github.com/NixOS/nixpkgs/commit/d4640395ac2f677d0543a77461d16f6910bd812e) | `gnome.tali: 40.2 -> 40.3`                                           |
| [`c117f55e`](https://github.com/NixOS/nixpkgs/commit/c117f55ee223b5e4c865c9f848e9effa395f58ac) | `exploitdb: 2021-09-21 -> 2021-09-22`                                |
| [`722a4c1a`](https://github.com/NixOS/nixpkgs/commit/722a4c1a54b93a5f12cb8aa9ce7f61c03dc09276) | `telegraf: 1.19.3 -> 1.20.0`                                         |
| [`1a922bc8`](https://github.com/NixOS/nixpkgs/commit/1a922bc8d670e6638248bacd0cf82698e0bc6fc2) | `python38Packages.google-cloud-dns: 0.33.0 -> 0.33.1`                |
| [`97567fcb`](https://github.com/NixOS/nixpkgs/commit/97567fcbdcff14235a7fc349a19de99e8712bca9) | `pantheon.appcenter: 3.7.1 -> 3.8.0`                                 |
| [`69a7a1e1`](https://github.com/NixOS/nixpkgs/commit/69a7a1e1a19e56cdda8031bdc25f41418a6d7280) | `python38Packages.google-crc32c: 1.1.3 -> 1.2.0`                     |
| [`32b32117`](https://github.com/NixOS/nixpkgs/commit/32b32117b0cccb37b1629e26082fb700754cd3ec) | `python38Packages.google-cloud-speech: 2.8.0 -> 2.9.0`               |
| [`b483ef3c`](https://github.com/NixOS/nixpkgs/commit/b483ef3cc866ae6afed65115ba6f0c6b19efce49) | `btrfs-progs: 5.13.1 -> 5.14.1`                                      |
| [`394ef2f8`](https://github.com/NixOS/nixpkgs/commit/394ef2f868c77973680fef03fca2628a122021af) | `python38Packages.google-cloud-runtimeconfig: 0.32.4 -> 0.32.5`      |
| [`ad24dc7a`](https://github.com/NixOS/nixpkgs/commit/ad24dc7a2d4c9c42309d0046a6465053eeb44b5d) | `python38Packages.google-cloud-spanner: 3.9.0 -> 3.10.0`             |
| [`7dd6d9a8`](https://github.com/NixOS/nixpkgs/commit/7dd6d9a8c168edd95a692f490222a1521c63edba) | `oil: 0.9.0 -> 0.9.2`                                                |
| [`0170ff4c`](https://github.com/NixOS/nixpkgs/commit/0170ff4c9598c0a01d687d5241198b0a78debfd7) | `conftest: 0.28.0 -> 0.28.1`                                         |
| [`89e1b623`](https://github.com/NixOS/nixpkgs/commit/89e1b6235802043d4a9200b40990c0bf1b236942) | `cloudflared: 2021.9.0 -> 2021.9.1`                                  |
| [`5d3f726f`](https://github.com/NixOS/nixpkgs/commit/5d3f726f0bab0fc367b30f6183a80542bdc5bd84) | `yq-go: 4.13.0 -> 4.13.2`                                            |
| [`2c1fc116`](https://github.com/NixOS/nixpkgs/commit/2c1fc1165ef7d42a9bcec2106864ae7daa499a66) | `cargo-supply-chain: fix darwin build`                               |
| [`769f21d0`](https://github.com/NixOS/nixpkgs/commit/769f21d0d6952229d5035718279367fe70f2406a) | `cargo-play: enable most of the tests`                               |
| [`55bf4e27`](https://github.com/NixOS/nixpkgs/commit/55bf4e27c4035760fbb78fb16d95382acd8a3cef) | `fits-cloudctl: set meta.mainProgram`                                |
| [`8eb28bed`](https://github.com/NixOS/nixpkgs/commit/8eb28bed2ffd9bbba0ab81f9ae0178639fb406b2) | `1password: Install polkit action file (#132478)`                    |
| [`3ce63d43`](https://github.com/NixOS/nixpkgs/commit/3ce63d43b38751253453c6c7236468ed1655a8ba) | `aws-workspaces: 3.1.8.1198 -> 4.0.1.1302`                           |
| [`5740fd7f`](https://github.com/NixOS/nixpkgs/commit/5740fd7f8982141636235fc0dc94828048c1a46f) | `vimPlugins.vim-textobj-entire: init at 2018-01-19`                  |
| [`277d3f65`](https://github.com/NixOS/nixpkgs/commit/277d3f6545cc887519dc70c58452ffa7ff545c62) | `vimPlugins.vim-fubitive: init at 2020-09-10`                        |
| [`325c47d0`](https://github.com/NixOS/nixpkgs/commit/325c47d00e30d4dd21128f231dba34ffefd4489c) | `vimPlugins.vifm-vim: init at 2021-09-21`                            |
| [`89fcf1d6`](https://github.com/NixOS/nixpkgs/commit/89fcf1d62e5dee7b43818bb1d5f9c542f0718a44) | `vimPlugins.slimv: init at 2021-08-24`                               |
| [`0bc25f85`](https://github.com/NixOS/nixpkgs/commit/0bc25f85706f376f95fc63d599c2a3c23c1e9661) | `vimPlugins.presenting-vim: init at 2021-06-02`                      |
| [`e09f3a16`](https://github.com/NixOS/nixpkgs/commit/e09f3a16975495451c9c88a306e9f6e515691ada) | `vimPlugins: update`                                                 |
| [`f18dd09f`](https://github.com/NixOS/nixpkgs/commit/f18dd09fc2e0dfac0418f40f4c56fbb97d0ef5c4) | `aws-workspaces: only leave wrapper script in bin`                   |
| [`a35c2235`](https://github.com/NixOS/nixpkgs/commit/a35c2235b79c59bfea8a86fb95919e450ce23409) | `panamax: init at 1.0.3`                                             |
| [`8d8b451f`](https://github.com/NixOS/nixpkgs/commit/8d8b451f725b63edec06b033ff2bdaa2f0885b4e) | `chromium: 93.0.4577.82 -> 94.0.4606.54`                             |
| [`56d99a73`](https://github.com/NixOS/nixpkgs/commit/56d99a735113e48d2ea51084804c5a59c5603a5f) | `chromiumDev: 95.0.4638.10 -> 95.0.4638.17`                          |
| [`ecca3b5e`](https://github.com/NixOS/nixpkgs/commit/ecca3b5e19756c46f7a510fee3ba656e718b5a4f) | `glitter: init at 1.4.4`                                             |
| [`c0d5bb2a`](https://github.com/NixOS/nixpkgs/commit/c0d5bb2ab4fb3e72c82a417fcfd6d7e6927d4ffa) | `python3Packages.angrop: 9.0.9947 -> 9.0.10010`                      |
| [`4c2aa4f9`](https://github.com/NixOS/nixpkgs/commit/4c2aa4f9745145c1b1bdec8a51e3b56d581d3478) | `python3Packages.angr: 9.0.9947 -> 9.0.10010`                        |
| [`75fa7b14`](https://github.com/NixOS/nixpkgs/commit/75fa7b1418796f2410550d975b57ffa449b68554) | `python3Packages.cle: 9.0.9947 -> 9.0.10010`                         |
| [`702360fc`](https://github.com/NixOS/nixpkgs/commit/702360fc8b254b9725075942c19289fd987b61dd) | `python3Packages.claripy: 9.0.9947 -> 9.0.10010`                     |
| [`15c3fa1d`](https://github.com/NixOS/nixpkgs/commit/15c3fa1d844e7ae760aeb043ac065643f3bb104e) | `python3Packages.pyvex: 9.0.9947 -> 9.0.10010`                       |
| [`7ee75928`](https://github.com/NixOS/nixpkgs/commit/7ee75928144f19cbe22d4142dbd14880d6693733) | `python3Packages.ailment: 9.0.9947 -> 9.0.10010`                     |
| [`7f1e75ab`](https://github.com/NixOS/nixpkgs/commit/7f1e75abccc7aa4af502afe9c3d97d9c5d285e72) | `python3Packages.archinfo: 9.0.9947 -> 9.0.10010`                    |
| [`f661c05a`](https://github.com/NixOS/nixpkgs/commit/f661c05a11fe2984ecf8e2c50274ad58f9e301a6) | `heisenbridge: 1.1.1 -> 1.1.2`                                       |
| [`ccb944e5`](https://github.com/NixOS/nixpkgs/commit/ccb944e58aa542e03d469296b284f00c6bb61e07) | `rhack: init at 0.1.0`                                               |
| [`a8b29bdb`](https://github.com/NixOS/nixpkgs/commit/a8b29bdb273f2f460c3f44cfaddb08fd6a79bdde) | `gitea: 1.15.2 -> 1.15.3`                                            |
| [`58371e54`](https://github.com/NixOS/nixpkgs/commit/58371e54a99046564bb019847662770179fdaa0f) | `nodePackages: update`                                               |
| [`f3db53c9`](https://github.com/NixOS/nixpkgs/commit/f3db53c98e317e0a65c83258be9dbc8b8bd1866a) | `vscode-extensions.vscode-lldb: 1.6.5 -> 1.6.7`                      |
| [`73c7b9c8`](https://github.com/NixOS/nixpkgs/commit/73c7b9c8c70b6b41b2a48ee718dc30a43bde2311) | `aws-workspaces: fix patchelf for liblttng-ust`                      |
| [`5237b517`](https://github.com/NixOS/nixpkgs/commit/5237b51754516e13fc6d392461bcab9024915310) | `fits-cloudctl: 0.9.11 -> 0.10.0`                                    |
| [`53c4bea5`](https://github.com/NixOS/nixpkgs/commit/53c4bea5093fc87b08bef5e6e3c45e2f6c2ce205) | `ksnip: Change license to `gpl2Plus``                                |
| [`24a2bad7`](https://github.com/NixOS/nixpkgs/commit/24a2bad7ec4ea1a0c05c72cf5b18b882d76734d2) | `linuxKernel.kernels.linux_xanmod: 5.14.4 -> 5.14.6`                 |
| [`1e54f840`](https://github.com/NixOS/nixpkgs/commit/1e54f84012afc15bb3432792980576d54cff60a3) | `nixos/netdata: fix working with disabled ipmi plugin`               |
| [`4c268ee2`](https://github.com/NixOS/nixpkgs/commit/4c268ee2ccb7d4eaec3830bee16fe67cfc39f269) | `ocrmypdf: move to python3Packages`                                  |
| [`fc1c501f`](https://github.com/NixOS/nixpkgs/commit/fc1c501f4c6e5ca4a90b48ce5bd5b9d631ce5772) | `python3Packages.pikepdf: 2.16.1 -> 3.0.0`                           |
| [`5e39a98d`](https://github.com/NixOS/nixpkgs/commit/5e39a98d15d03326b260a0429936494bb9eb3237) | `ksnip: Remove deleted packages from `all-packages``                 |
| [`d687093e`](https://github.com/NixOS/nixpkgs/commit/d687093e669d40fe99f51e67889eb1bf3fa230ed) | `ksnip: Use existing packages for dependencies`                      |
| [`9ac0b848`](https://github.com/NixOS/nixpkgs/commit/9ac0b8488797bf2f0bc676337c494df2fb305588) | `ksnip: Move dependencies from `nativeBuildInputs` to `buildInputs`` |
| [`4f1e2dbc`](https://github.com/NixOS/nixpkgs/commit/4f1e2dbc73ccf8c81a77debcfddd3ec23d9f5303) | `ksnip: Build from source`                                           |
| [`5f54cb62`](https://github.com/NixOS/nixpkgs/commit/5f54cb62e1bcea49e6811e5a6106a8370ba2eec0) | `ksnip: init at 1.9.1`                                               |
| [`6a1014f1`](https://github.com/NixOS/nixpkgs/commit/6a1014f1b4f3613bf5088d3b55f3e17efc1fa96f) | `wordpress: 5.8 -> 5.8.1`                                            |
| [`46ede392`](https://github.com/NixOS/nixpkgs/commit/46ede3924cc87ed00eb191752cba28656ad1d949) | `python3Packages.einops: init at 0.3.2`                              |
| [`d97f0e95`](https://github.com/NixOS/nixpkgs/commit/d97f0e95d0dc1aba2af9e12b4586c0c68fe965d2) | `python38Packages.google-crc32c: 1.1.2 -> 1.1.3`                     |
| [`e56bddf0`](https://github.com/NixOS/nixpkgs/commit/e56bddf0dfad81c60b199c0ed1e004452960f863) | `vmTools: fix cross compilation`                                     |