### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2491eb3bdcaf23a2af625d8698470f2a0eac6e72",
-        "sha256": "1fnilshf0qy714pkk6637bn2lfk0mznvvp0gl381jhdgv1kl7h7g",
+        "rev": "e9540c5f121d77c68de0f2156cb6f9869d95a6f8",
+        "sha256": "0s0i6x78nxjyc0a885hzvwh5bylccixiam6c5h1q6pa64aqx50pc",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/2491eb3bdcaf23a2af625d8698470f2a0eac6e72.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/e9540c5f121d77c68de0f2156cb6f9869d95a6f8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                  |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`99b632b2`](https://github.com/NixOS/nixpkgs/commit/99b632b2208b69911f3ca48cc0f5fb095e2d2314) | `python38Packages.yt-dlp: 2021.9.2 -> 2021.9.25`                |
| [`e95a50a6`](https://github.com/NixOS/nixpkgs/commit/e95a50a64b4061ab2cb0572ac493f841e7b65b14) | `nixos/networkd: add ActivationPolicy option`                   |
| [`780415ce`](https://github.com/NixOS/nixpkgs/commit/780415ce5d5bf3df6e361178206cd1185c56c4b9) | `cargo-llvm-lines: 0.4.11 -> 0.4.12`                            |
| [`de68426d`](https://github.com/NixOS/nixpkgs/commit/de68426db81f8061923b283118d5d7f6582b3c29) | `ocamlPackages.labltk: add version 8.06.11 for OCaml 4.13`      |
| [`5f7019ed`](https://github.com/NixOS/nixpkgs/commit/5f7019ed8a8ad8af7a4db18a12fe2fb8955a647a) | `prisma: 2.30.2 -> 3.1.1`                                       |
| [`0f9a1d70`](https://github.com/NixOS/nixpkgs/commit/0f9a1d70fad4af54a0d411b306427823476dcced) | `meilisearch: add docs`                                         |
| [`faef9593`](https://github.com/NixOS/nixpkgs/commit/faef95930b1b52b93d8c98cdf5032fdcbfb93a3f) | `meilisearch: add meta`                                         |
| [`847bfb3d`](https://github.com/NixOS/nixpkgs/commit/847bfb3df34b42daca5203c4828af57a46538d8f) | `tdesktop: 3.1.0 -> 3.1.1`                                      |
| [`8bc030eb`](https://github.com/NixOS/nixpkgs/commit/8bc030eb13ea2fd611e446042340e9f19aa218e4) | `llvmPackages_13: 13.0.0-rc3 -> 13.0.0-rc4`                     |
| [`3bc4a574`](https://github.com/NixOS/nixpkgs/commit/3bc4a574dbb1674cf99eda99bb4af364c9c8472a) | `prisma: add pimeys as maintainer`                              |
| [`47557e29`](https://github.com/NixOS/nixpkgs/commit/47557e2984cac84711bf3aad6213dade0907116f) | `nodesPackages.prisma: #135934 follow-up corrections`           |
| [`d047d336`](https://github.com/NixOS/nixpkgs/commit/d047d336d60433a07c8e0de2dee45cfad8ceecef) | `prisma-engines: #135934 follow-up corrections`                 |
| [`88cdb0a3`](https://github.com/NixOS/nixpkgs/commit/88cdb0a3c041ab6a401c6776de548e72bb332e22) | `wifite2: add pixiewps dependency`                              |
| [`54051ba4`](https://github.com/NixOS/nixpkgs/commit/54051ba41855a1bbbe8ebe4d6f87386604fb6df9) | `comby: 1.5.1 -> 1.7.0`                                         |
| [`29efb76a`](https://github.com/NixOS/nixpkgs/commit/29efb76ab6480426ce8c1f7bd8e341f0249a61cc) | `google-chrome: add pipewire dependency`                        |
| [`2fb9f65c`](https://github.com/NixOS/nixpkgs/commit/2fb9f65c0a1c9d6624b5c0a237b3eaa9d14b8dcd) | `comby: nixpkgs-fmt`                                            |
| [`ccb5c228`](https://github.com/NixOS/nixpkgs/commit/ccb5c2285b2f8110ae469ac23e2cad63f761ed95) | `perlPackages.ConvertASN1: 0.27 -> 0.33`                        |
| [`d800b42d`](https://github.com/NixOS/nixpkgs/commit/d800b42dec422dcf09f908f2065ef310e5fb38b4) | `udunits: meta.platforms = lib.platforms.all`                   |
| [`df02d2b1`](https://github.com/NixOS/nixpkgs/commit/df02d2b17570f569c50e9e5fd340697d0272cd8c) | `python38Packages.goalzero: 0.1.59 -> 0.2.0`                    |
| [`29ba0603`](https://github.com/NixOS/nixpkgs/commit/29ba06034e1f9d17f260240a24020beb5ddddaad) | `python38Packages.fountains: 1.0.0 -> 1.1.0`                    |
| [`54974715`](https://github.com/NixOS/nixpkgs/commit/5497471572f8a8c4e0ca1b44bfd4de854023b85d) | `python38Packages.deemix: 3.5.1 -> 3.5.3`                       |
| [`98fe3260`](https://github.com/NixOS/nixpkgs/commit/98fe3260c624d94726aec9ff7f7c4f2f456ceea1) | `nixos/gnome: Fix broken .gnome-shell-wrapped wrapper`          |
| [`a7943950`](https://github.com/NixOS/nixpkgs/commit/a79439501f2c40dde884f59b32ef0d5f8701b091) | `gdu: 5.8.0 -> 5.8.1`                                           |
| [`f779a0ff`](https://github.com/NixOS/nixpkgs/commit/f779a0ff03497e83dab5b04182c13cd2ef347274) | `nix-output-monitor: 1.0.3.2 -> 1.0.3.3`                        |
| [`3cfee020`](https://github.com/NixOS/nixpkgs/commit/3cfee020814ceaa8a5a5a5ba2de87efcae62c2db) | `pythonPackages.python-osc: init at 1.7.7`                      |
| [`08b2a9c9`](https://github.com/NixOS/nixpkgs/commit/08b2a9c91f77ab7d58e9e301ee3e857fb8dd9362) | `maintainers: add anirrudh`                                     |
| [`76ba113d`](https://github.com/NixOS/nixpkgs/commit/76ba113d716004273d26ecf5a61e5f89cd7c41d6) | `nodejs-16_x: 16.9.1 -> 16.10.0`                                |
| [`f855ba46`](https://github.com/NixOS/nixpkgs/commit/f855ba4667740c00b60cd38e1a521585ab6fd978) | `go-migrate: 4.14.1 -> 4.15.0`                                  |
| [`615d368a`](https://github.com/NixOS/nixpkgs/commit/615d368aa000279f1c63d9c5521859181b5fbfe3) | `nixUnstable: 2.4pre20210908_3c56f62 -> 2.4pre20210922_bcd73eb` |
| [`fa884f12`](https://github.com/NixOS/nixpkgs/commit/fa884f123b474fe001a9bfe558afc4341a06db4d) | `python3Packages.pytest-cases: 3.6.3 -> 3.6.4`                  |
| [`006c32f1`](https://github.com/NixOS/nixpkgs/commit/006c32f161d23af58a730643c7bd1d6b09348045) | `rPackages.RclusTool: add to packges requiring X`               |
| [`ff79a754`](https://github.com/NixOS/nixpkgs/commit/ff79a754ca73ce6753ab0d06b91fd7aed402ccda) | `cnijfilter2: 6.00 -> 6.10`                                     |
| [`cac8c4fe`](https://github.com/NixOS/nixpkgs/commit/cac8c4fe3dd5ae3a7806c522345eebc94299d82e) | `ethash: 0.7.0 -> 0.7.1`                                        |