### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1737f98af6667560e3e4f930312f9b5002649d04",
-        "sha256": "0jdiw9wjyqvbrnigwjxinars6203ql550f0wlp70j1rr7cn7fmjz",
+        "rev": "af45dae72dc6288f07af7af0dd1b93f9c906065b",
+        "sha256": "1phws03l6azp00673mf12n3cn66kyifqk5brfn0a27ij8dg2ns7l",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/1737f98af6667560e3e4f930312f9b5002649d04.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/af45dae72dc6288f07af7af0dd1b93f9c906065b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                             |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`457ff383`](https://github.com/NixOS/nixpkgs/commit/457ff3835c48d091fe0ba9e16dc8381703469c09) | `doc: fix misspelling (#139623)`                                           |
| [`843dca38`](https://github.com/NixOS/nixpkgs/commit/843dca38b836801f153d43669d2f95852d6aa637) | `fdtools: pin to older skalibs version`                                    |
| [`bf33c0e6`](https://github.com/NixOS/nixpkgs/commit/bf33c0e62e24d95edd7808ff6c19409212da1f96) | `skawarePackages: Fall 2021 release`                                       |
| [`1cbb0fea`](https://github.com/NixOS/nixpkgs/commit/1cbb0feae596544af67bec58c8282de9e31d807b) | `erlang: fix nix-env version confusion`                                    |
| [`39f0cfdd`](https://github.com/NixOS/nixpkgs/commit/39f0cfdd12119d991225c6ab2d7e4483d67cf0a3) | `vimPlugins.deoplete-emoji: Drop plugin`                                   |
| [`320235ce`](https://github.com/NixOS/nixpkgs/commit/320235ce214d1078eb98cccabc1c2287a66b4680) | `vimUtils.packDir: expose packDir function`                                |
| [`ed8c4e01`](https://github.com/NixOS/nixpkgs/commit/ed8c4e01d985d115f8821106318afc65fc7eaf5f) | `discourse: Enable jhead, which is no longer marked vulnerable`            |
| [`e4ed6b59`](https://github.com/NixOS/nixpkgs/commit/e4ed6b5929d56328e79ad8792568790f6c077251) | `discourse.plugins.discourse-yearly-review: Update`                        |
| [`957eaf82`](https://github.com/NixOS/nixpkgs/commit/957eaf8237a44f6849716739d35057b7ceaba84c) | `discourse.plugins.discourse-spoiler-alert: Update`                        |
| [`fd084acb`](https://github.com/NixOS/nixpkgs/commit/fd084acb95f3e80a80405924e44002e2e4f6dd0e) | `discourse.plugins.discourse-solved: Update`                               |
| [`b1aa7efd`](https://github.com/NixOS/nixpkgs/commit/b1aa7efd36d1e8c9df8f97602038b98533f84cf9) | `discourse.plugins.discourse-math: Update`                                 |
| [`97034cfa`](https://github.com/NixOS/nixpkgs/commit/97034cfa1c3b455f1114fea8d302925014dd4bd8) | `discourse.plugins.discourse-github: Update`                               |
| [`77187783`](https://github.com/NixOS/nixpkgs/commit/77187783c4544c8c455e29fd5da1b3af6402ef9a) | `python3Packages.fe25519: 0.3.0 -> 1.0.0`                                  |
| [`56c47107`](https://github.com/NixOS/nixpkgs/commit/56c4710770540700f2b02e2a94a692cc5a4541dd) | `python3Packages.ge25519: 0.2.0 -> 1.0.0`                                  |
| [`1dd78cbd`](https://github.com/NixOS/nixpkgs/commit/1dd78cbd74e8b85354d8902ead8090ae3f69d170) | `resholve: 0.6.5 -> 0.6.6, respect buildInputs`                            |
| [`407ff075`](https://github.com/NixOS/nixpkgs/commit/407ff07598afac2754d83923aff1b9e4f5e5d66a) | `resholve: 0.6.4 -> 0.6.5`                                                 |
| [`8b2cd3a7`](https://github.com/NixOS/nixpkgs/commit/8b2cd3a79af041687d60c475c4462a25c60bf351) | `resholve: 0.6.3 -> 0.6.4`                                                 |
| [`679b29d3`](https://github.com/NixOS/nixpkgs/commit/679b29d33d8fc2609cbc6789512075b9af918dd3) | `resholve: 0.6.2 -> 0.6.3, fix readme`                                     |
| [`6568f18e`](https://github.com/NixOS/nixpkgs/commit/6568f18ea3a3b32f53cbcd2db90915128edd21d3) | `resholve: 0.6.1 -> 0.6.2`                                                 |
| [`b5833091`](https://github.com/NixOS/nixpkgs/commit/b5833091d4d24e7a742df703a4b02acfe8f4ecb1) | `resholve: 0.6.0 -> 0.6.1, add resholveScript* fns`                        |
| [`67ec4fa4`](https://github.com/NixOS/nixpkgs/commit/67ec4fa479b82a264ee647785df261f0f12b7f05) | `resholve: fix review nits from #138080`                                   |
| [`a649cbca`](https://github.com/NixOS/nixpkgs/commit/a649cbca0948c39c43c63b790c75b5b6e4db1564) | `resholvePackage: extract util functions`                                  |
| [`541fd993`](https://github.com/NixOS/nixpkgs/commit/541fd9936db69116a94fb3dbe9eff5bd00c4460f) | `home-assistant: update component-packages`                                |
| [`194eb792`](https://github.com/NixOS/nixpkgs/commit/194eb792885f676df6098ae97692192e0a3abbf2) | `python3Packages.lupupy: init at 0.0.21`                                   |
| [`7b03c7ee`](https://github.com/NixOS/nixpkgs/commit/7b03c7ee60844ecab58d45bd06e2c5f2f8336e64) | `vikunja-frontend: 0.18.0 -> 0.18.1`                                       |
| [`b24780c6`](https://github.com/NixOS/nixpkgs/commit/b24780c6b427c26ac24d745bf75111a6ea9f0138) | `vikunja-api: 0.18.0 -> 1.18.1`                                            |
| [`d08244d5`](https://github.com/NixOS/nixpkgs/commit/d08244d50ea6696a9fdf297fa2d81a30072ca039) | `sydbox: init at 2.2.0`                                                    |
| [`5655e71e`](https://github.com/NixOS/nixpkgs/commit/5655e71eeeb7c47908ac92b3ff2f6c5073a30d76) | `lighttpd: remove null defaults for input packages`                        |
| [`8a585fd5`](https://github.com/NixOS/nixpkgs/commit/8a585fd5c59bebb04434e2b7d0bfac1123b0a919) | `nixos/lighttpd: support new authentication modules`                       |
| [`baa04706`](https://github.com/NixOS/nixpkgs/commit/baa04706d7ac4b8c0d6c6d0eab41158176c25d36) | `lighttpd: add build options for new auth methods`                         |
| [`cc49c13a`](https://github.com/NixOS/nixpkgs/commit/cc49c13a6bad964951093705128ab6c40c202066) | `nixos/postfix: Fix virtual alias manpage section`                         |
| [`e50975e8`](https://github.com/NixOS/nixpkgs/commit/e50975e89d4405b0a7a82738207d8e7768fcd2dc) | `vsce/zxh404.vscode-proto3: init at 0.5.4`                                 |
| [`f9c7333b`](https://github.com/NixOS/nixpkgs/commit/f9c7333bce5312e88795fb1f22b6191b93f45b07) | `ocamlPackages.qcheck: 0.17 → 0.18`                                        |
| [`b99e43a9`](https://github.com/NixOS/nixpkgs/commit/b99e43a96eb85dc845f9e47afe71dbbaf1560ba7) | `ocamlPackages.reason-native.qcheck-rely: mark as broken`                  |
| [`f548ac9c`](https://github.com/NixOS/nixpkgs/commit/f548ac9c6cac47d36d9ed8c999b83c561b97f34d) | `ocamlPackages.iter: disable tests with OCaml < 4.08`                      |
| [`8c32eb1a`](https://github.com/NixOS/nixpkgs/commit/8c32eb1a99963124c9a1203c690bddad796b7d8e) | `ocamlPackages.psq: disable tests with OCaml < 4.08`                       |
| [`c5a5f7b1`](https://github.com/NixOS/nixpkgs/commit/c5a5f7b13df1191656974122d8a1a8b090fd810f) | `ocamlPackages.lru: disable tests with OCaml < 4.08`                       |
| [`6f85b0fa`](https://github.com/NixOS/nixpkgs/commit/6f85b0fa7b3b190152acb168ec2624697621891b) | `ocamlPackages.syslog-message: disable tests with OCaml < 4.08`            |
| [`09f33fd8`](https://github.com/NixOS/nixpkgs/commit/09f33fd8aa06f5b5522cb50b309ee548fc3df4fe) | `ocamlPackages.stdint: disable tests with OCaml < 4.08`                    |
| [`049ca38a`](https://github.com/NixOS/nixpkgs/commit/049ca38a0c84f7c41467b006712340fd52f00043) | `ocamlPackages.containers: disable tests with OCaml < 4.08`                |
| [`5f16f0a9`](https://github.com/NixOS/nixpkgs/commit/5f16f0a9cf2b5b5249382e19b8e2206dbfb9fd12) | `ocamlPackages.batteries: disable tests with OCaml < 4.08`                 |
| [`801b070c`](https://github.com/NixOS/nixpkgs/commit/801b070c408b49d7ee8b0c82378eafde26fcb9d0) | `ocamlPackages.stringext: disable tests with OCaml < 4.08`                 |
| [`bb7692db`](https://github.com/NixOS/nixpkgs/commit/bb7692db80c2fb76d349b188e72f56e3e911451c) | `ocamlPackages.gen: disable tests with OCaml < 4.08`                       |
| [`e6654828`](https://github.com/NixOS/nixpkgs/commit/e6654828b8be4e89cd1ef01424aca412b009d87a) | `bashdb: 4.4-1.0.0 -> 5.0-1.1.2, fix build with bash 5.1`                  |
| [`564e2a51`](https://github.com/NixOS/nixpkgs/commit/564e2a51876c8062727222e58ddb0fbd96289b1e) | `leo-editor: add meta.mainProgram`                                         |
| [`5d5170c5`](https://github.com/NixOS/nixpkgs/commit/5d5170c5d7719fb9e85012cdda03e6dde8ec30ad) | `fcitx5-rime: 5.0.6 -> 5.0.7`                                              |
| [`3ef60d4e`](https://github.com/NixOS/nixpkgs/commit/3ef60d4ee42c84be5baf71a2eb0f7deb4fe4a6b9) | `fcitx5: 5.0.8 -> 5.0.9`                                                   |
| [`f339e9af`](https://github.com/NixOS/nixpkgs/commit/f339e9af4205498f7e003beb799d21dad5a43b33) | `sumneko-lua-language-server: set meta.mainProgram`                        |
| [`5bd537cc`](https://github.com/NixOS/nixpkgs/commit/5bd537ccef03f3010e7709b170d6368cde45927e) | `fclones: 0.15.0 -> 0.16.0`                                                |
| [`a3fa65e4`](https://github.com/NixOS/nixpkgs/commit/a3fa65e48f0cb03e83f8eb16f31fa2cfec0ab606) | `linuxKernel.kernels.linux_xanmod: 5.14.7 -> 5.14.8`                       |
| [`b20e68e6`](https://github.com/NixOS/nixpkgs/commit/b20e68e6230cb137b0fc23b38423465fbd4ba82a) | `trebleshot: remove`                                                       |
| [`cf28ad7e`](https://github.com/NixOS/nixpkgs/commit/cf28ad7e6f7cd14e489c5326a54117827f7cf89d) | `python3Packages.python3-application: refactor`                            |
| [`aa4c5bb7`](https://github.com/NixOS/nixpkgs/commit/aa4c5bb7cf0eb2210bad93483a26a8bb155cd814) | `hedgedoc: fix build by re-running `yarn2nix``                             |
| [`ca4e61d5`](https://github.com/NixOS/nixpkgs/commit/ca4e61d58607c65691f32c31e4add106b27dfd2b) | `yarn2nix: run `nix-prefetch-git` with `--fetch-submodules``               |
| [`1ec1836d`](https://github.com/NixOS/nixpkgs/commit/1ec1836dfeee36a4616e5a34b5e19fd28669a88e) | `vimPlugins.inkpot: init at 2013-02-10`                                    |
| [`89da7764`](https://github.com/NixOS/nixpkgs/commit/89da7764efd809a2238a5d6e2788e8e523df7444) | `quilt: add smancill as maintainer`                                        |
| [`0f77179b`](https://github.com/NixOS/nixpkgs/commit/0f77179bcfa2e821d98889423d1f8a18e22952ee) | `quilt: wrap all required inputs`                                          |
| [`bb21f231`](https://github.com/NixOS/nixpkgs/commit/bb21f231cf1556318346f7476a2ae4cc234c2cd6) | `linux/hardened/patches/5.4: 5.4.147-hardened1 -> 5.4.148-hardened1`       |
| [`5b71d92f`](https://github.com/NixOS/nixpkgs/commit/5b71d92f9ad21a39b8ed957b1d5d54ecb5536da6) | `linux/hardened/patches/5.14: 5.14.6-hardened1 -> 5.14.7-hardened1`        |
| [`34fe5d82`](https://github.com/NixOS/nixpkgs/commit/34fe5d827ca5a1cee89b5abfde73a540977f3722) | `linux/hardened/patches/5.10: 5.10.67-hardened1 -> 5.10.68-hardened1`      |
| [`b754a3c3`](https://github.com/NixOS/nixpkgs/commit/b754a3c355b21bd2d4503d0f1b5b7c98448e5496) | `linux/hardened/patches/4.19: 4.19.206-hardened1 -> 4.19.207-hardened1`    |
| [`7b29a72e`](https://github.com/NixOS/nixpkgs/commit/7b29a72e545ee913dbdb07b8379d7d7ccd08b173) | `linux/hardened/patches/4.14: 4.14.246-hardened1 -> 4.14.247-hardened1`    |
| [`fa3a7105`](https://github.com/NixOS/nixpkgs/commit/fa3a7105266abd6f9302d8864dbd60283204a314) | `linux: 5.4.148 -> 5.4.149`                                                |
| [`10fee833`](https://github.com/NixOS/nixpkgs/commit/10fee833c9220242961d9f7b7d3a82c0a3a1a407) | `linux: 5.14.7 -> 5.14.8`                                                  |
| [`bba95d37`](https://github.com/NixOS/nixpkgs/commit/bba95d376306c37e535e3ab5555ac2f9279afaa5) | `linux: 5.10.68 -> 5.10.69`                                                |
| [`bb9a54d5`](https://github.com/NixOS/nixpkgs/commit/bb9a54d5ee3c1d28e64ff0a05cd0960a4313cf93) | `linux: 4.9.283 -> 4.9.284`                                                |
| [`bae26c4e`](https://github.com/NixOS/nixpkgs/commit/bae26c4e05ddb2cf032e875c4a8d2ba06e44e4c0) | `linux: 4.4.284 -> 4.4.285`                                                |
| [`7fad9899`](https://github.com/NixOS/nixpkgs/commit/7fad98993cd0da2f14ea30e895f168c7eebfba40) | `linux: 4.19.207 -> 4.19.208`                                              |
| [`b0f3a99f`](https://github.com/NixOS/nixpkgs/commit/b0f3a99f00efe85145a5c537a2d25865e3f39a53) | `linux: 4.14.247 -> 4.14.248`                                              |
| [`9eb60cdf`](https://github.com/NixOS/nixpkgs/commit/9eb60cdf4e2755c06298ad0404afaf3aa4de07b2) | `emacs.pkgs.bqn-mode: 2021-09-15 -> 2021-09-26`                            |
| [`cb28af90`](https://github.com/NixOS/nixpkgs/commit/cb28af904528e23f3c345821210a5a2d4c7e0370) | `matcha-gtk-theme: 2021-08-23 -> 2021-09-24`                               |
| [`c43789e7`](https://github.com/NixOS/nixpkgs/commit/c43789e7bb3768e0a084e4bf79366212d4a69f4b) | `julia_16-bin: 1.6.2 -> 1.6.3`                                             |
| [`6ae909d1`](https://github.com/NixOS/nixpkgs/commit/6ae909d1839c2d40dcb05f596add39eccde1b690) | `vnote: 2.10 -> 3.7.0`                                                     |
| [`e7d24168`](https://github.com/NixOS/nixpkgs/commit/e7d2416831020fe4b894fd6db202d2beb66d569f) | `ytcc: 2.3.0 -> 2.4.1`                                                     |
| [`9e1a79a0`](https://github.com/NixOS/nixpkgs/commit/9e1a79a05f7067aaa2763c6e2a142c012b1b47a4) | `libarchive-qt 2.0.4 -> 2.0.6`                                             |
| [`f59bceb7`](https://github.com/NixOS/nixpkgs/commit/f59bceb7f785f50ba7c3dd0e8e0b9ea20143a71c) | `vsce/kamikillerto.vscode-colorize: init at 0.11.1`                        |
| [`5309818b`](https://github.com/NixOS/nixpkgs/commit/5309818bf744a166a236ee2f829c154975cf6bcc) | `doc: clarify location of rPackages overrides`                             |
| [`bd077a5b`](https://github.com/NixOS/nixpkgs/commit/bd077a5b4204d1ec60067329a7065c8d85baea26) | `python3Packages.pyezviz: 0.1.9.3 -> 0.1.9.4`                              |
| [`646cb17c`](https://github.com/NixOS/nixpkgs/commit/646cb17cdb142128e3d90c7e718da57ef355136d) | `feh: 3.7.1 -> 3.7.2`                                                      |
| [`fd08bea7`](https://github.com/NixOS/nixpkgs/commit/fd08bea7f7740b265abae6bbccaa4a87be0fbcd9) | `libsForQt5.mauikit-filebrowsing: 2.0.1 -> 2.0.2`                          |
| [`cf4d5a3a`](https://github.com/NixOS/nixpkgs/commit/cf4d5a3a319c699381878d75e608263f672a116c) | `libsForQt5.mauikit: 2.0.1 -> 2.0.2`                                       |
| [`10a0b29d`](https://github.com/NixOS/nixpkgs/commit/10a0b29d211e8228cef9bf32b10623c8d1756291) | `apfsprogs: unstable-2021-05-07 -> unstable-2021-08-24`                    |
| [`b5f27628`](https://github.com/NixOS/nixpkgs/commit/b5f27628e4ad2dc3d84ee41af6251b8ad5174880) | `greybird: 3.22.14 -> 3.22.15`                                             |
| [`d66e4eea`](https://github.com/NixOS/nixpkgs/commit/d66e4eea8550cc10d2f579b4e821639d44deae01) | `ungoogled-chromium: 94.0.4606.54 -> 94.0.4606.61`                         |
| [`ea678f70`](https://github.com/NixOS/nixpkgs/commit/ea678f709fd3c39bd044a62df5e141dcefb98ed3) | `python38Packages.phonenumbers: 8.12.32 -> 8.12.33`                        |
| [`804e2edf`](https://github.com/NixOS/nixpkgs/commit/804e2edff596e667d287556cfd3a701bad1648b3) | `flutter: 2.2.1 -> 2.5.1`                                                  |
| [`d6069f5c`](https://github.com/NixOS/nixpkgs/commit/d6069f5c5e12a8c8827748e9fa45635e3bd948e6) | `zabbix: add IPMI support`                                                 |
| [`d80676b7`](https://github.com/NixOS/nixpkgs/commit/d80676b76badc497bf4ba657dc019ff5a0fb5945) | `shotcut: 21.03.21 -> 21.09.20`                                            |
| [`98ea8a9d`](https://github.com/NixOS/nixpkgs/commit/98ea8a9dba31705e437c78b95f7ed9d200e0f309) | `shotcut: clarify license as gpl3Plus`                                     |
| [`9bc37bff`](https://github.com/NixOS/nixpkgs/commit/9bc37bff1afd0bc3fc5b851ee4512ea4478fc583) | `rPackages: mark packages as broken when generating package sets`          |
| [`1574f8ce`](https://github.com/NixOS/nixpkgs/commit/1574f8ceca5b9d633ef2099947ce9c3c47e4acf4) | `teleport: 7.1.2 -> 7.1.3`                                                 |
| [`d5830017`](https://github.com/NixOS/nixpkgs/commit/d583001723e9ad4588c5b54c9f27c111758fe105) | `discourse.plugins.discourse-checklist: Update`                            |
| [`1e62b64b`](https://github.com/NixOS/nixpkgs/commit/1e62b64b9036a3e9332b60c838f658ee35fa0a5a) | `discourse.plugins.discourse-canned-replies: Update`                       |
| [`d62ea870`](https://github.com/NixOS/nixpkgs/commit/d62ea8705b22c8163fcbc6dcb7c70a42e7e745fe) | `discourse.plugins.discourse-calendar: Update`                             |
| [`73e8eb91`](https://github.com/NixOS/nixpkgs/commit/73e8eb91c122699e5ede88980f7c7ef727b29896) | `discourse: 2.7.7 -> 2.7.8`                                                |
| [`7001a467`](https://github.com/NixOS/nixpkgs/commit/7001a46766ee32dffdfab5e52081350ada72fcac) | `nixos/snapper: services.snapperd sync serviceConfig with upstream`        |
| [`25d3e6d0`](https://github.com/NixOS/nixpkgs/commit/25d3e6d01fcd8cbdbc1c5690a0930f5ecdd94078) | `nixos/snapper: add snapshotRootOnBoot option`                             |
| [`e8388f85`](https://github.com/NixOS/nixpkgs/commit/e8388f8574679ea0dce73934b9b97d2efe76e886) | `nixos/switch-to-configuration: Allow activation scripts to restart units` |
| [`05a7f008`](https://github.com/NixOS/nixpkgs/commit/05a7f0086347f85bfd052d1f3e6128a2afc12103) | `sigrok-cli: 0.7.1 -> 0.7.2`                                               |
| [`ec0be1a6`](https://github.com/NixOS/nixpkgs/commit/ec0be1a65f53bb3777ef55c483c49c4cdb23f4fd) | `sdrangel: 6.16.2 -> 6.16.3`                                               |
| [`48826482`](https://github.com/NixOS/nixpkgs/commit/48826482213c06937e400eadf89bcda6afea7eda) | `iosevka-bin: 10.0.0 -> 10.1.0`                                            |