### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "96606addcedb821d311c701788062b8864346838",
-        "sha256": "1pja0yrwcj13nbbqakyfsfb90szi0m9lfz4wygm9c7s8gagqxd29",
+        "rev": "8e3b899626f353fee56fbb518d277c7d337f2100",
+        "sha256": "0a0fdr6jxjc0i6qs8fk5mvprr170bl68089syzw01zs1jrh2qfjg",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/96606addcedb821d311c701788062b8864346838.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/8e3b899626f353fee56fbb518d277c7d337f2100.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                            |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`e3066b5e`](https://github.com/NixOS/nixpkgs/commit/e3066b5e9f649082456211782075b5044a68d30d) | `vmTools: fixup after adding the `img` package`                           |
| [`ad7eb5b4`](https://github.com/NixOS/nixpkgs/commit/ad7eb5b4e60f2343142c52e272b112faa0feaa5e) | `higan: 110 -> 115+unstable=2021-08-18`                                   |
| [`589e03f1`](https://github.com/NixOS/nixpkgs/commit/589e03f109092a3ba97781fd0533110bf78a3f97) | `diffoscope: 183 -> 185`                                                  |
| [`209b1e43`](https://github.com/NixOS/nixpkgs/commit/209b1e43471a853883ca3c862006894585baeb01) | `gocryptfs: ensure fusermount setuid wrapper is used if present`          |
| [`008e1264`](https://github.com/NixOS/nixpkgs/commit/008e12644853b85e8e0741e5815aa4fcf3df3423) | `mopidy-ytmusic: init at 0.3.2`                                           |
| [`c4112ea9`](https://github.com/NixOS/nixpkgs/commit/c4112ea936a3b681f3983079de84586b571c59b4) | `mopidy-mpd: 3.0.0 -> 3.2.0`                                              |
| [`c642999a`](https://github.com/NixOS/nixpkgs/commit/c642999add458f1761e66aafeb19d8c504ab89c5) | `expolitdb: 2021-09-29 -> 2021-09-30`                                     |
| [`62d2fc1c`](https://github.com/NixOS/nixpkgs/commit/62d2fc1ccae90859243351474a9e9e0614bc017d) | `leiningen: 2.9.6 -> 2.9.7`                                               |
| [`e1f3bc62`](https://github.com/NixOS/nixpkgs/commit/e1f3bc6204d9317f21237fd765deac2d70a1f410) | `mopidy-mpris: 3.0.2 -> 3.0.3`                                            |
| [`ffea2549`](https://github.com/NixOS/nixpkgs/commit/ffea254935c36683607aeb95f281a5eb0158313f) | `heisenbridge: 1.2.0 -> 1.2.1`                                            |
| [`c0a8ff18`](https://github.com/NixOS/nixpkgs/commit/c0a8ff18be21f289cf65dc3da15e99df698425bd) | `python38Packages.lazy_import: quote homepage (#140031)`                  |
| [`6431f731`](https://github.com/NixOS/nixpkgs/commit/6431f7316fed74810bbc13c69ed718d7f7075064) | `python38Packages.tensorboard-plugin-wit: quote homepage (#140034)`       |
| [`becb0478`](https://github.com/NixOS/nixpkgs/commit/becb04784c1e06f96e70a0135deb2e0dd79c4d70) | `python3Packages.millheater: 0.5.2 -> 0.6.0`                              |
| [`1d696ae8`](https://github.com/NixOS/nixpkgs/commit/1d696ae86febb3b074987c67f318167d1ce2782e) | `python38Packages.packet-python: 1.44.0 -> 1.44.1`                        |
| [`c3e39c51`](https://github.com/NixOS/nixpkgs/commit/c3e39c51a71ea2df84091ebef954cf5cd7057121) | `nextcloud-client: 3.3.4 -> 3.3.5`                                        |
| [`3a07e14f`](https://github.com/NixOS/nixpkgs/commit/3a07e14fe9c6077209cd4f12bacb23d601985677) | `nvme-cli: 1.14 -> 1.15`                                                  |
| [`41f22bd5`](https://github.com/NixOS/nixpkgs/commit/41f22bd5c727b670819b0b1933a284425b182c25) | `python38Packages.mypy-boto3-s3: 1.18.50 -> 1.18.51`                      |
| [`963773ea`](https://github.com/NixOS/nixpkgs/commit/963773eafa5e390ecd01069de0ab40d79f2eb4f7) | `zellij: 0.18.0 -> 0.18.1`                                                |
| [`8346dc04`](https://github.com/NixOS/nixpkgs/commit/8346dc04b31bc4ade35bd15a72e6cc40c8ac2f73) | `pict-rs: add initial module`                                             |
| [`1320843a`](https://github.com/NixOS/nixpkgs/commit/1320843aade014d9c199296c6dc0528de11451cd) | `pict-rs: fixes`                                                          |
| [`2e13a9cc`](https://github.com/NixOS/nixpkgs/commit/2e13a9cc6d8420e7d778127b36ff0ad6a8158f33) | `electrs: fix missing metrics feature`                                    |
| [`37d2d14c`](https://github.com/NixOS/nixpkgs/commit/37d2d14c04c2b6aadb63ca9a19f0c5e9bde7c057) | `friture: fix desktop item`                                               |
| [`802321a4`](https://github.com/NixOS/nixpkgs/commit/802321a44282f7bf716fce0e4a14ac46d607456e) | `signal-desktop: 5.17.2 -> 5.18.0`                                        |
| [`f94419a3`](https://github.com/NixOS/nixpkgs/commit/f94419a3a87be8adad25bb81662aefa9384a8226) | `libva-utils: 2.12.0 -> 2.13.0`                                           |
| [`b5da25f1`](https://github.com/NixOS/nixpkgs/commit/b5da25f1c9edbbcc01b9dd19e95d6eb149498463) | `dnstake: init at 0.0.2 (#139869)`                                        |
| [`97dc734a`](https://github.com/NixOS/nixpkgs/commit/97dc734ab591b8b26e0d2f9c54dd5d6eac022a00) | `python38Packages.imbalanced-learn: 0.8.0 -> 0.8.1`                       |
| [`81328a0f`](https://github.com/NixOS/nixpkgs/commit/81328a0f6a3fe95fbdb500e551e14d3c4a8f0a70) | `python3Packages.total-connect-client: 2021.7.1 -> 2021.8.3`              |
| [`22aad265`](https://github.com/NixOS/nixpkgs/commit/22aad26526a06d85079d4488ade82dea451e07ce) | `source-han-*: use fetchzip instead of mkDerivation`                      |
| [`2e262587`](https://github.com/NixOS/nixpkgs/commit/2e262587ae0810ebb4f1e65d1d73efb72a5d74a5) | `python38Packages.google-cloud-spanner: 3.10.0 -> 3.11.0`                 |
| [`a41e19ca`](https://github.com/NixOS/nixpkgs/commit/a41e19ca718eeabc2e9205e72608f50a933e9648) | `chromiumBeta: 95.0.4638.17 -> 95.0.4638.32`                              |
| [`6703f159`](https://github.com/NixOS/nixpkgs/commit/6703f159a79e066f751c66968becbe68f2c6bfc0) | `ko: 0.8.3 -> 0.9.3`                                                      |
| [`c2b15153`](https://github.com/NixOS/nixpkgs/commit/c2b15153a8f982fda721034cb9e62e0b01768008) | `electrs: 0.8.12 -> 0.9.0`                                                |
| [`4236dfe2`](https://github.com/NixOS/nixpkgs/commit/4236dfe203c24c1cee4b6705fed9c36e90115e8b) | `jre_minimal: document how to use a headless JDK`                         |
| [`1e97c325`](https://github.com/NixOS/nixpkgs/commit/1e97c325b3f3a28cb6e156941f4876385f6fd19e) | `pcloud: 1.9.5 -> 1.9.7`                                                  |
| [`27983d14`](https://github.com/NixOS/nixpkgs/commit/27983d14543382a70293fd4bbc449cdc52e0d0df) | `python3Packages.pynobo: 1.2.0 -> 1.3.0`                                  |
| [`155362f3`](https://github.com/NixOS/nixpkgs/commit/155362f36cd92cff3ccf91ffd4322d51d4bb568e) | `python3Packages.somecomfort: 0.5.2 -> 0.6.0`                             |
| [`443fba35`](https://github.com/NixOS/nixpkgs/commit/443fba3566be4480d1ad463d4acf482270257173) | `python38Packages.cx_Freeze: 6.7 -> 6.8.1`                                |
| [`e6276d6d`](https://github.com/NixOS/nixpkgs/commit/e6276d6da39a636f74b78db54480b40d8e8165ce) | `python38Packages.cupy: 9.4.0 -> 9.5.0`                                   |
| [`d62a5652`](https://github.com/NixOS/nixpkgs/commit/d62a56529049d0cece44261f09fff1dc7b7a6042) | `haruna: 0.6.3 -> 0.7.2`                                                  |
| [`36e96619`](https://github.com/NixOS/nixpkgs/commit/36e96619438ba8a08f6080dbb53ab34aa1bb63f1) | `home-assistant: enable mythicbeastsdns tests`                            |
| [`1dd8f94d`](https://github.com/NixOS/nixpkgs/commit/1dd8f94d72c3b66bce210fd205b471dda2dca814) | `python3Packages.mypy-boto3-builder: 5.4.0 -> 5.5.0`                      |
| [`265006a4`](https://github.com/NixOS/nixpkgs/commit/265006a49312a5f2251a961c64f843aaa2306f9c) | `python38Packages.holidays: 0.11.3 -> 0.11.3.1`                           |
| [`824043e0`](https://github.com/NixOS/nixpkgs/commit/824043e09c9421d6750f60abca9b23d7699868ea) | `ocamlPackages.uucd: 13.0.0 → 14.0.0`                                     |
| [`93d737f7`](https://github.com/NixOS/nixpkgs/commit/93d737f732c15fe0afa94196f2e92645eaaa223d) | `python38Packages.ephem: 4.0.0.2 -> 4.1`                                  |
| [`c779050e`](https://github.com/NixOS/nixpkgs/commit/c779050edb56f5958d28af7aec444c14f6a18163) | `poetry2nix: 1.20.0 -> 1.21.0`                                            |
| [`e5b3f177`](https://github.com/NixOS/nixpkgs/commit/e5b3f1774423af475f7019a22d8c72d180ef6f2d) | `pantheon.gala: 6.2.0 -> 6.2.1`                                           |
| [`c4035d72`](https://github.com/NixOS/nixpkgs/commit/c4035d7234d3b020e230f1094ae1e5efd64d7aa0) | `saleae-logic-2: add desktop item`                                        |
| [`8bcd17d6`](https://github.com/NixOS/nixpkgs/commit/8bcd17d6a859b44b24e5ef5d14e0fc6a2eaf9c69) | `terraform_1_0: 1.0.7 -> 1.0.8`                                           |
| [`1f7f8739`](https://github.com/NixOS/nixpkgs/commit/1f7f87396ca180543b997a3a8806212da8a3fd67) | `chromiumDev: 96.0.4651.0 -> 96.0.4655.0`                                 |
| [`8b1e1396`](https://github.com/NixOS/nixpkgs/commit/8b1e1396225790a0a1fb7961a4848c773737cff9) | `photoflow: mark as broken`                                               |
| [`3b57a720`](https://github.com/NixOS/nixpkgs/commit/3b57a720fb5968171241cd18e77f064ce4daa450) | `desmume: update meta.homepage`                                           |
| [`f2e6a515`](https://github.com/NixOS/nixpkgs/commit/f2e6a515a590e8615794428b18df7bf20f5d32cc) | `qtcreator: add elfutils.dev and perf to build the perfparse plugin`      |
| [`c5ea68e6`](https://github.com/NixOS/nixpkgs/commit/c5ea68e6b9c5cfc6578cc91e1d7ff2ebf7f1d236) | `google-java-format: init at 1.11.0`                                      |
| [`3e86f355`](https://github.com/NixOS/nixpkgs/commit/3e86f355803aa6b0ea97ebab1db76602577d86f4) | `hunspellDicts.nl_nl: move cc-by-nc-30 out of the license field since it` |
| [`97bdb492`](https://github.com/NixOS/nixpkgs/commit/97bdb492cb9686c9774254dd46b6ccc3c97b47f3) | `img: init 0.5.11`                                                        |
| [`2becca7d`](https://github.com/NixOS/nixpkgs/commit/2becca7d444dcf365b66f647d4fed440ead8a883) | `zola: aarch64-darwin support fixup`                                      |
| [`110165b7`](https://github.com/NixOS/nixpkgs/commit/110165b784c838a46ac9ab8d6d300e7d3981b1a3) | `Provide submodule to `security.wrappers` for older kernels`              |
| [`97ff96c8`](https://github.com/NixOS/nixpkgs/commit/97ff96c8466898ab11a06891a45654125d148f63) | `zellij: 0.17.0 -> 0.18.0`                                                |
| [`0b612ad3`](https://github.com/NixOS/nixpkgs/commit/0b612ad35ab1603b91937882a1e2cfcb7fc81c7f) | `git-quickfix: init at 0.0.4`                                             |
| [`884ebdc4`](https://github.com/NixOS/nixpkgs/commit/884ebdc49cc81e1a269fe45a9a42c59e565e102d) | `gdome2: fix build on -fno-common toolchains`                             |
| [`737e6038`](https://github.com/NixOS/nixpkgs/commit/737e6038551e2a85242f727317e583216563ec07) | `h3: enable on darwin`                                                    |
| [`3a784c49`](https://github.com/NixOS/nixpkgs/commit/3a784c4963918c462dd2e81e055c2404ec9ea2cf) | `nextpnr: 2021.08.16 -> 2021.09.27`                                       |
| [`d4745713`](https://github.com/NixOS/nixpkgs/commit/d474571392299484825073668b69db786897f7f0) | `symbiyosys: 2020.08.22 -> 2021.09.13`                                    |
| [`874ebfd5`](https://github.com/NixOS/nixpkgs/commit/874ebfd5a85bc1b4b99951f40b89003e4a78da80) | `yosys: 0.9+4276 -> 0.10+1`                                               |
| [`b242dadb`](https://github.com/NixOS/nixpkgs/commit/b242dadba1cb0a51e88843dab29c3bc5cc556747) | `python38Packages.zodbpickle: 2.0.0 -> 2.2.0`                             |
| [`6bf8ddeb`](https://github.com/NixOS/nixpkgs/commit/6bf8ddeb5a41d16578f088023ef16b369792a601) | `libspng: 0.7.0-rc3 -> 0.7.0`                                             |
| [`d7a85018`](https://github.com/NixOS/nixpkgs/commit/d7a85018482d184f4043b6fac356e9aff05e3800) | `haskell.packages.ghc921: jailbreak splitmix`                             |
| [`f8e0a33f`](https://github.com/NixOS/nixpkgs/commit/f8e0a33f3139209e04664fa0c1462d5b18150c73) | `python38Packages.transmission-rpc: 3.2.8 -> 3.3.0`                       |
| [`17927dee`](https://github.com/NixOS/nixpkgs/commit/17927dee0943215054e7dd518f68024f2cafdbb7) | `wgetpaste: 2.30 -> 2.32`                                                 |
| [`cccf01a5`](https://github.com/NixOS/nixpkgs/commit/cccf01a57b8021333b2c28dc195148429648f565) | `re2: 2021-08-01 -> 2021-09-01`                                           |
| [`de0bf891`](https://github.com/NixOS/nixpkgs/commit/de0bf891e9ca0578e6014f16c91be777aa52106f) | `btop: 1.0.9 -> 1.0.10`                                                   |
| [`a4046060`](https://github.com/NixOS/nixpkgs/commit/a4046060985704af7f01cb8e4f57143f0a5c43ea) | `postgresqlPackages.timescaledb: 2.4.1 -> 2.4.2`                          |
| [`d56c52d7`](https://github.com/NixOS/nixpkgs/commit/d56c52d769cb241915bc4d25e759e4d292220a7a) | `libfyaml: 0.7 -> 0.7.1`                                                  |
| [`a6cbe889`](https://github.com/NixOS/nixpkgs/commit/a6cbe8893c2f9312a6ff5398a6efe213670384d9) | `pspg: install bash completions`                                          |
| [`09784546`](https://github.com/NixOS/nixpkgs/commit/09784546d628b8489681fa66a831f7b42e292ce2) | `pgsync: 0.6.7 -> 0.6.8`                                                  |
| [`3ac24ca9`](https://github.com/NixOS/nixpkgs/commit/3ac24ca94a963444082a09a045bd110491a17b79) | `teleport: 7.1.3 -> 7.2.0`                                                |
| [`d678d2ec`](https://github.com/NixOS/nixpkgs/commit/d678d2ec698e9e710c36c2b71084ad0ca6814c34) | `elpa-generated: manual fixup`                                            |
| [`ad8c3200`](https://github.com/NixOS/nixpkgs/commit/ad8c3200e72d08cf2c681b795fd71f38a5c64ab2) | `elpa-packages 2021-09-29`                                                |
| [`61598989`](https://github.com/NixOS/nixpkgs/commit/61598989427c63aff9ae9df9ebfed26aff25f875) | `melpa-packages 2021-09-29`                                               |
| [`4b677819`](https://github.com/NixOS/nixpkgs/commit/4b6778192ea6360ce5c837e5bdde060c55c0d535) | `svgcleaner: 0.9.2 -> 0.9.5`                                              |
| [`76fd780b`](https://github.com/NixOS/nixpkgs/commit/76fd780bd1b61982b4f936dc5af4401253225b47) | `rambox: 0.7.8 -> 0.7.9`                                                  |
| [`a774af36`](https://github.com/NixOS/nixpkgs/commit/a774af3605a86719f813ccb80e9f8a5bdef2ee0a) | `psi-notify: move systemd unit to $out/lib`                               |
| [`c294019f`](https://github.com/NixOS/nixpkgs/commit/c294019fa3fafd7d70ad1d73ce5ecc40d5981baf) | `gobang: init at 0.1.0-alpha.5`                                           |
| [`34540742`](https://github.com/NixOS/nixpkgs/commit/3454074241d7c40b7a701f2b24928a1f37d1b4c6) | `python38Packages.sentry-sdk: 1.4.2 -> 1.4.3`                             |
| [`410b8656`](https://github.com/NixOS/nixpkgs/commit/410b86569652c7ce635e073a5b35558edd495777) | `nnn: 4.2 → 4.3`                                                          |
| [`4368954e`](https://github.com/NixOS/nixpkgs/commit/4368954e3bf74a71af22991c577e7d06a8746041) | `limesctl: init at 2.0.0`                                                 |
| [`dbcac0ae`](https://github.com/NixOS/nixpkgs/commit/dbcac0ae61ce2d766a71939106a954d1320e1257) | `rubyPackages: update`                                                    |
| [`58be2300`](https://github.com/NixOS/nixpkgs/commit/58be230026659b11cce8ac0d97f937149689889c) | `nixos/tests/custom-ca: falkon -> qutebrowser`                            |
| [`0901b410`](https://github.com/NixOS/nixpkgs/commit/0901b41056f5dde3fb01a9998145ff8b7ca11136) | `source-han-sans: 2.001 -> 2.004`                                         |
| [`db58f62d`](https://github.com/NixOS/nixpkgs/commit/db58f62dab8fdba1ca31def9ed92313b6ff70562) | `home-assistant: update component-packages`                               |
| [`fcceea46`](https://github.com/NixOS/nixpkgs/commit/fcceea469fd8086e52265d958d0f71d20a6ba217) | `python3Packages.wazeroutecalculator: rename`                             |
| [`316bc514`](https://github.com/NixOS/nixpkgs/commit/316bc514fa3691208bfc074feae5fb551a73c92d) | `rar: init at 6.0.2`                                                      |
| [`1702fa2a`](https://github.com/NixOS/nixpkgs/commit/1702fa2a3bf6228ae213a7e74605508c4d2f8b18) | `postgresqlPackages.plpgsql_check: 1.16.0 -> 2.0.2`                       |
| [`460d5cfd`](https://github.com/NixOS/nixpkgs/commit/460d5cfd43540e18f70fd16e501c151b094eed70) | `python3Packages.urlextract: init at 1.3.0`                               |
| [`14a43b0b`](https://github.com/NixOS/nixpkgs/commit/14a43b0b6268d728642e9d8f8a382467782d4697) | `maintainers: add ilkecan`                                                |
| [`1a429c43`](https://github.com/NixOS/nixpkgs/commit/1a429c43fd5311fe5f317997e45aa2a5330348c7) | `python39Packages.grpcio-tools: 1.40.0 -> 1.41.0`                         |
| [`834adab1`](https://github.com/NixOS/nixpkgs/commit/834adab12a14fc77582086aa0d0817773c424071) | `nanorc: remove nixfmt to prevent accidental updates from r-ryantm`       |
| [`3334018e`](https://github.com/NixOS/nixpkgs/commit/3334018e524e2ca4c03b1a0c145e2129092d8dc7) | `grpc: 1.40.0 -> 1.41.0`                                                  |
| [`f466e933`](https://github.com/NixOS/nixpkgs/commit/f466e9337c40a44050bfa2f18cc0681f90fa6fbc) | `pngquant: 2.14.1 -> 2.16.0`                                              |
| [`9ac537d0`](https://github.com/NixOS/nixpkgs/commit/9ac537d08b9fe91575518868f5e0645e9e31fc29) | `python3Packages.WazeRouteCalculator: 0.12 -> 0.13`                       |
| [`7960244e`](https://github.com/NixOS/nixpkgs/commit/7960244eb1eeae9e3fb6dceaca72fd70814063c4) | `nixos/tests: fix for memorySize being an integer`                        |
| [`2c4a128d`](https://github.com/NixOS/nixpkgs/commit/2c4a128d6212f4cf5ef934630b68efcc76a07560) | `haskellPackages.{Kulitta, Jazzkell}: clean up eval errors on darwin`     |
| [`4d2f1399`](https://github.com/NixOS/nixpkgs/commit/4d2f1399e9259f028c7e16e9171b3b09bdd68534) | `haskellPackages: mark builds failing on hydra as broken`                 |
| [`97e02b4b`](https://github.com/NixOS/nixpkgs/commit/97e02b4b8746dc65af4bd2f7251296ec9e0cb00c) | `haskellPackages.hw-*: fix too tight bounds on generic-lens`              |
| [`cdffe459`](https://github.com/NixOS/nixpkgs/commit/cdffe459d8cb4697670fc3fa9eba10f839f7a990) | `haskellPackages.hls-rename-plugin: provide necessary test env`           |
| [`159e57e0`](https://github.com/NixOS/nixpkgs/commit/159e57e0abfd46c910946a31f741b568885f0ee4) | `clojure: 1.10.3.943 -> 1.10.3.986`                                       |
| [`e8ec90a2`](https://github.com/NixOS/nixpkgs/commit/e8ec90a29be33e4fef38b5582febe4194a34eabf) | `python3Packages.pycontrol4: 0.1.0 -> 0.3.0`                              |
| [`98d3de67`](https://github.com/NixOS/nixpkgs/commit/98d3de674607109c58161da5af8fb6e62765d80c) | `python38Packages.ipyvue: 1.5.0 -> 1.6.0`                                 |
| [`e92cd507`](https://github.com/NixOS/nixpkgs/commit/e92cd507531081fc77b0a8d0ab1cda7ae13c5bea) | `nongnu-packages 2021-09-29`                                              |
| [`a9dffd93`](https://github.com/NixOS/nixpkgs/commit/a9dffd937eeb152630938b9b3c9328192e1334be) | `org-packages 2021-09-29`                                                 |
| [`1497e8f5`](https://github.com/NixOS/nixpkgs/commit/1497e8f5f58eeb0bbc0cf97a0267db101726049b) | `nixos/qemu: use set -e in shell script`                                  |
| [`f5a81c9e`](https://github.com/NixOS/nixpkgs/commit/f5a81c9e61902733bfcdbefbd8c9973cdfc44871) | `nodejs: 14.17.6 -> 14.18.0`                                              |
| [`41515cc4`](https://github.com/NixOS/nixpkgs/commit/41515cc4504ab1fe668b835af80d3ce2e46de4d4) | `haskell.packages.ghc921: use hashable_1_3_3_0`                           |
| [`d8ff7944`](https://github.com/NixOS/nixpkgs/commit/d8ff7944ede3210c2172b87517803e25b8ed4736) | `grocy: 3.1.1 -> 3.1.2`                                                   |
| [`6b7280c7`](https://github.com/NixOS/nixpkgs/commit/6b7280c7cd5ae205a760c16f6618124ce682c6c5) | `python3Packages.async-upnp-client: 0.21.3 -> 0.22.4`                     |
| [`e8b91f30`](https://github.com/NixOS/nixpkgs/commit/e8b91f3064525cde7c8766546fc0c1495aa1fe79) | `haskellPackages.cabal2nix-unstable: 2021-09-23 -> 2021-09-28`            |
| [`ca33fe38`](https://github.com/NixOS/nixpkgs/commit/ca33fe38ad110aeeb346a570499a70c1648ce45b) | `haskellPackages.procex: don't mark as broken`                            |
| [`7d5fe512`](https://github.com/NixOS/nixpkgs/commit/7d5fe512ff7992c2ec1e80034f9daf30784a4db1) | `taplo-cli: 0.4.0 -> 0.4.1`                                               |
| [`f0b20bad`](https://github.com/NixOS/nixpkgs/commit/f0b20bad9cb42db3223c88290a2163faaaca7976) | `coreboot-toolchain: Init at 4.14`                                        |
| [`778481f1`](https://github.com/NixOS/nixpkgs/commit/778481f1c696b0ec27eec92cedcc87bb7ce7c368) | `noisetorch: 0.11.3 -> 0.11.4`                                            |
| [`8fc3c06c`](https://github.com/NixOS/nixpkgs/commit/8fc3c06c6c5882187b470732b93f55f6227cd99f) | `miniflux: 2.0.31 -> 2.0.33`                                              |
| [`c7b75118`](https://github.com/NixOS/nixpkgs/commit/c7b75118d214c1f431fb70971f487f9947b19b14) | `python38Packages.snowflake-connector-python: 2.6.1 -> 2.6.2`             |
| [`3b0afe2e`](https://github.com/NixOS/nixpkgs/commit/3b0afe2ee4ea98818c214b82f246dfe8547182f2) | `source-han-*: install instead of ln`                                     |
| [`180f7099`](https://github.com/NixOS/nixpkgs/commit/180f7099015a2a7bee53294d9c3b7c8ac284f55c) | `stgit: 1.1 -> 1.3`                                                       |
| [`9a506d40`](https://github.com/NixOS/nixpkgs/commit/9a506d40321fb672a8b9543dfbda875188b617cb) | `swayr: 0.6.2 -> 0.7.0`                                                   |
| [`5ae3ae8e`](https://github.com/NixOS/nixpkgs/commit/5ae3ae8e166b3848064a10e08e294eadd12b1c81) | `wshowkeys: switch to a working fork`                                     |