### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8e3b899626f353fee56fbb518d277c7d337f2100",
-        "sha256": "0a0fdr6jxjc0i6qs8fk5mvprr170bl68089syzw01zs1jrh2qfjg",
+        "rev": "6d898617a22b02d5f1ac5c46a703f6ecc3c39cea",
+        "sha256": "0br9ard0swh6nwwm4h12m5glm9wp3rvw2vs7dqdj3qsr6ivddl86",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/8e3b899626f353fee56fbb518d277c7d337f2100.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/6d898617a22b02d5f1ac5c46a703f6ecc3c39cea.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                               |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`d9d63e1f`](https://github.com/NixOS/nixpkgs/commit/d9d63e1f16479b23030277fd835e78cb6a275e82) | `vimPlugins.cmp-tabnine: init at 2021-09-30`                                 |
| [`3a1cbf0d`](https://github.com/NixOS/nixpkgs/commit/3a1cbf0df4875fa063f57433340928656a2363f2) | `vimPlugins: update`                                                         |
| [`33b7bd26`](https://github.com/NixOS/nixpkgs/commit/33b7bd2675b8f336224f737fb84e03316ae32e01) | `nixos/gdm: switch to rfc42 style settings`                                  |
| [`c41fcde2`](https://github.com/NixOS/nixpkgs/commit/c41fcde24d96c1c0547c9b717dae4f6054176035) | `python3Packages.aioesphomeapi: 9.1.1 -> 9.1.2`                              |
| [`309b14df`](https://github.com/NixOS/nixpkgs/commit/309b14dfcd579b8fc0c8a796871a11648b6e1a7d) | `haskellPackages.quic: provide correct version of network`                   |
| [`9485e605`](https://github.com/NixOS/nixpkgs/commit/9485e6053e061e8ae4b29f5bc09021c3538e2650) | `haskellPackages: mark builds failing on hydra as broken`                    |
| [`937f349b`](https://github.com/NixOS/nixpkgs/commit/937f349b5f6ed47591fc373017175efb9cf4d13e) | `rxvt-unicode: fix terminfo path`                                            |
| [`c29f8005`](https://github.com/NixOS/nixpkgs/commit/c29f8005d0d097e1981e6ea84570382ac88a938e) | `gerrit: 3.4.0 -> 3.4.1`                                                     |
| [`e8e1ba49`](https://github.com/NixOS/nixpkgs/commit/e8e1ba49b20c2cb00f5895e6771e2444c5f10bc9) | `python38Packages.sqlmap: 1.5.9 -> 1.5.10`                                   |
| [`3e29ee6b`](https://github.com/NixOS/nixpkgs/commit/3e29ee6b71ad9522ec37e14d1ab777f0cba7eecb) | `trunk: 0.13.1 -> 0.14.0`                                                    |
| [`93f38e0a`](https://github.com/NixOS/nixpkgs/commit/93f38e0a7b45bd04683b9d51c4bd0f2a6c65ee5e) | `haskell.packages.ghc921: use network_3_1_2_2`                               |
| [`15b78276`](https://github.com/NixOS/nixpkgs/commit/15b78276daed361e65c307b39daeb4f3ff1870c8) | `haskell.packages.ghc921: re-enable tests previously blocked by 'random'`    |
| [`dcff69a8`](https://github.com/NixOS/nixpkgs/commit/dcff69a84019eb4a98d6a7eebd8bb921d97e5ddd) | `haskell.packages.ghc921.ChasingBottoms: remove markBrokenVersion`           |
| [`3533a384`](https://github.com/NixOS/nixpkgs/commit/3533a38478ede359cf230b32f3badfb24eaf1e63) | `haskell.packages.ghc921: use random_1_2_1`                                  |
| [`35813c6f`](https://github.com/NixOS/nixpkgs/commit/35813c6f04d74f6ad3f3cbe64976aa549ab17478) | `haskellPackages.candid: 0.2 -> 0.3`                                         |
| [`675e262f`](https://github.com/NixOS/nixpkgs/commit/675e262f5a03eb9aa6b0500434ee30a9d6b882a0) | `nixos/nextcloud: temp fix for MariaDB >=10.6`                               |
| [`c32ea917`](https://github.com/NixOS/nixpkgs/commit/c32ea917d0df019f2e28aab1f3ca074f8698c5af) | `haskellPackages.candid: add workaround for doctest failure`                 |
| [`b30b2863`](https://github.com/NixOS/nixpkgs/commit/b30b286371cf649631f99c8ccc0ba4d462673743) | `Add myself as maintainer for a few Haskell packages`                        |
| [`8a19707f`](https://github.com/NixOS/nixpkgs/commit/8a19707fc4ca624b08a8b00b25c0202d31a2a2f5) | `natls: init at 2.1.14`                                                      |
| [`e890cef8`](https://github.com/NixOS/nixpkgs/commit/e890cef8571b899191098395ce5d73e573fb3e86) | `diffoscope: 185 -> 186`                                                     |
| [`f0d1af9b`](https://github.com/NixOS/nixpkgs/commit/f0d1af9bd48aa5071725dc75a76aaa1a0c716fa1) | `tp-auto-kbbl: init at 0.1.5`                                                |
| [`6b9eefb8`](https://github.com/NixOS/nixpkgs/commit/6b9eefb85f59c6d0d91b26180c9e1a2b42cb9f7f) | `php80: 8.0.10 -> 8.0.11`                                                    |
| [`13d37ebb`](https://github.com/NixOS/nixpkgs/commit/13d37ebb64a5e314aad5895c98da886b64886d25) | `php74: 7.4.23 -> 7.4.24`                                                    |
| [`920474b7`](https://github.com/NixOS/nixpkgs/commit/920474b7f7751c4f79a67cafd938d1a2df798d4f) | `gotify: 2.0.21 -> 2.1.0`                                                    |
| [`82155ff5`](https://github.com/NixOS/nixpkgs/commit/82155ff501c7622cb2336646bb62f7624261f6d7) | `rime-array: 2016-09-01 -> 2021-08-24 (#140008)`                             |
| [`72a893c9`](https://github.com/NixOS/nixpkgs/commit/72a893c9d07fbed8ecade2a9998588aac2645268) | `mold: 0.9.3 -> 0.9.6 (#139920)`                                             |
| [`b2bdfd67`](https://github.com/NixOS/nixpkgs/commit/b2bdfd67eb912bee77e1af9214a1a8e635af8191) | `kea: 1.9.11 -> 2.0.0`                                                       |
| [`67ac0371`](https://github.com/NixOS/nixpkgs/commit/67ac0371bca98cbb3b30e65e6c2b4ca1887ad442) | `vimPlugins.nvim-cursorline: init at 2021-09-28`                             |
| [`60385180`](https://github.com/NixOS/nixpkgs/commit/6038518014b4933c0baac44e0dee94592a8137db) | `vimPlugins.TrueZen-nvim: init at 2021-09-11`                                |
| [`52428b73`](https://github.com/NixOS/nixpkgs/commit/52428b73f65f9454717cc4718ad41252a883df42) | `vimPlugins: update`                                                         |
| [`378d2c5d`](https://github.com/NixOS/nixpkgs/commit/378d2c5dcec7fef958cca3760448c09a9be2b7a3) | `erofs-utils: 1.2.1 -> 1.3`                                                  |
| [`4a719dfa`](https://github.com/NixOS/nixpkgs/commit/4a719dfa45192030f38dccf099c17cbe8279d9ca) | `unrar: 5.9.2 -> 6.0.7`                                                      |
| [`4b5042ca`](https://github.com/NixOS/nixpkgs/commit/4b5042caf31af1e6eb750658a9bf547471228d75) | `coqPackages.paramcoq: 1.1.2 → 1.1.3`                                        |
| [`decdbc35`](https://github.com/NixOS/nixpkgs/commit/decdbc35693d4edbb6b084c4e344ca3db182365a) | `qemu: enable hvf acceleration on aarch64-darwin (#139960)`                  |
| [`642ca739`](https://github.com/NixOS/nixpkgs/commit/642ca73937decde097a6c83205f48a5ac081fe94) | `linux/hardened/patches/5.4: 5.4.149-hardened1 -> 5.4.150-hardened1`         |
| [`dd93aec4`](https://github.com/NixOS/nixpkgs/commit/dd93aec4c4905c17f17020658ed1f5858c9d6b81) | `linux/hardened/patches/5.14: 5.14.8-hardened1 -> 5.14.9-hardened1`          |
| [`f178ff4a`](https://github.com/NixOS/nixpkgs/commit/f178ff4a04c8d4e2ed43e6538a1aac336bfa891c) | `linux/hardened/patches/5.10: 5.10.69-hardened1 -> 5.10.70-hardened1`        |
| [`6937daff`](https://github.com/NixOS/nixpkgs/commit/6937daff0d376cfe33ec7945f768a66beaee0eaf) | `linux: 5.4.149 -> 5.4.150`                                                  |
| [`b540e8b5`](https://github.com/NixOS/nixpkgs/commit/b540e8b5a9082f8150fb3de37e793bc5cef25388) | `linux: 5.14.8 -> 5.14.9`                                                    |
| [`8417ed79`](https://github.com/NixOS/nixpkgs/commit/8417ed79d87f44c35af2e698921988c6525eedb1) | `linux: 5.10.69 -> 5.10.70`                                                  |
| [`ea41520b`](https://github.com/NixOS/nixpkgs/commit/ea41520b71bfc07668a535feae1abe093e0139e5) | `gitRepo: 2.16.8 -> 2.17`                                                    |
| [`20233d45`](https://github.com/NixOS/nixpkgs/commit/20233d45c4ec992e5094e858b25e6531d80466e0) | `clojure-lsp: 2021.09.13-22.25.35 -> 2021.09.30-15.28.01`                    |
| [`a9454f53`](https://github.com/NixOS/nixpkgs/commit/a9454f539b02b99d4192ff9964050368bda5e13f) | `resholve: actually import resholveScript*`                                  |
| [`5e2c33f1`](https://github.com/NixOS/nixpkgs/commit/5e2c33f1049432cb76492d0eb12fb74a0ecd8875) | `emu2: unstable-2020-06-04 -> 0.0.0+unstable=2021-09-22`                     |
| [`651f0046`](https://github.com/NixOS/nixpkgs/commit/651f00467f35e2d64f061e910bef5ea439359a82) | `soapysdr: enable on darwin`                                                 |
| [`6ff40871`](https://github.com/NixOS/nixpkgs/commit/6ff40871c0a5873ef510ff10a1edbef327bc6ae6) | `wget2: 1.99.2 -> 2.0.0`                                                     |
| [`49573709`](https://github.com/NixOS/nixpkgs/commit/49573709c5f842f0e3fbe4da3cd02f1c74aa9b1b) | `nextcloud: 20.0.12 -> 20.0.13, 21.0.4 -> 21.0.5, 22.1.1 -> 22.2.0`          |
| [`d55ffa5a`](https://github.com/NixOS/nixpkgs/commit/d55ffa5a2fd1fb9f0ed4ec93bd27f0990a2cb2f9) | `haskellPackages.nvfetcher: disable check`                                   |
| [`a807cd3a`](https://github.com/NixOS/nixpkgs/commit/a807cd3a00e49dfbb37572faa84158fbe2ebac51) | `nixos/extra-container: init`                                                |
| [`e02190a5`](https://github.com/NixOS/nixpkgs/commit/e02190a5d08e90f0a51ab7d8dce228ae34942a0a) | `extra-container: init at 0.8`                                               |
| [`5cc05024`](https://github.com/NixOS/nixpkgs/commit/5cc050244d338a8ccbfc152f6146b98da6069700) | `dasel: 1.20.0 -> 1.21.1`                                                    |
| [`48eba3e3`](https://github.com/NixOS/nixpkgs/commit/48eba3e35c10d11b709af420f96a346022a6fc55) | `ocamlPackages.lustre-v6: init at 6.103.3`                                   |
| [`f1132b0f`](https://github.com/NixOS/nixpkgs/commit/f1132b0ff1e3b7f4fc3a8dfece06607854c7fbaa) | `ocaml-lsp: 1.7.0 -> 1.8.3`                                                  |
| [`073cc84c`](https://github.com/NixOS/nixpkgs/commit/073cc84c9b87157d2df46dbc3deaaddb6fe77e42) | `ocamlformat-rpc-lib: init at 0.19.0`                                        |
| [`52b10ee8`](https://github.com/NixOS/nixpkgs/commit/52b10ee8725e3fde6bb5fc297b997d7c1bc59930) | `vmTools refactor: don't use huge `with pkgs;``                              |
| [`52babc1b`](https://github.com/NixOS/nixpkgs/commit/52babc1baa2bf01e6d897e784e3f8706d4fac8fb) | `glab: 1.20.0 -> 1.21.1`                                                     |
| [`4725dfec`](https://github.com/NixOS/nixpkgs/commit/4725dfecf6e987d32d5035e93abb2299653bb72d) | `google-java-format: fix for jdk 16`                                         |
| [`f848a875`](https://github.com/NixOS/nixpkgs/commit/f848a875360ccf9bd72467879b8370119c88d5dd) | `tailscale: add support for Darwin`                                          |
| [`53527927`](https://github.com/NixOS/nixpkgs/commit/53527927eb4c0cee87388f9460fbb0c25755ce35) | `cbqn: init at 0.0.0+unstable=2021-09-29`                                    |
| [`e3b85ac8`](https://github.com/NixOS/nixpkgs/commit/e3b85ac8bc72b12670804962305ec4b3985bf29e) | `clj-kondo: 2021.03.31 -> 2021.09.25`                                        |
| [`6fd63365`](https://github.com/NixOS/nixpkgs/commit/6fd63365fc48f27e3cf355f5d5c097a8af77d34f) | `koka: 2.1.9 -> 2.3.1`                                                       |
| [`0ec6fc72`](https://github.com/NixOS/nixpkgs/commit/0ec6fc72a0cc81a53684b3a816c89e6511250a58) | `hledger-check-fancyassertions: init at 1.23`                                |
| [`f6703cdd`](https://github.com/NixOS/nixpkgs/commit/f6703cdddc551769a1b8c41e8a300400facdb3a2) | `haskellPackages.hledger-lib_1_23: build with doctest 0.18.1`                |
| [`9a6d6c36`](https://github.com/NixOS/nixpkgs/commit/9a6d6c36e7888cb98f50ad84658a352884922ea9) | `haskellPackages.hls-call-hierarchy-plugin: dontCheck on darwin`             |
| [`c1e2fc60`](https://github.com/NixOS/nixpkgs/commit/c1e2fc6045f576b29d4950d61ca26e8dc6a4411b) | `gdown: 3.13.1 -> 3.14.0`                                                    |
| [`1aa48d7f`](https://github.com/NixOS/nixpkgs/commit/1aa48d7fd6bd874d90b7e8da1680fa9d92a5d9cf) | `sc68: unstable-2020-05-18 -> unstable-2021-08-23`                           |
| [`76b1e16c`](https://github.com/NixOS/nixpkgs/commit/76b1e16c6659ccef7187ca69b287525fea133244) | `postgresql_14: beta3 -> 14.0`                                               |
| [`094ce659`](https://github.com/NixOS/nixpkgs/commit/094ce6598bd5832a3c3a45bd0edd20a8ff274672) | `lab: 0.22.0 -> 0.23.0`                                                      |
| [`d8a7d226`](https://github.com/NixOS/nixpkgs/commit/d8a7d2262c79e953a936ef810fd487a829655b7f) | `postgresqlPackages.pg_cron: 1.3.1 -> 1.4.1`                                 |
| [`95356604`](https://github.com/NixOS/nixpkgs/commit/953566041065b510dfa83bfab5899a88ee07da79) | `bochs: Enable nogui display backend`                                        |
| [`f1cdcd73`](https://github.com/NixOS/nixpkgs/commit/f1cdcd739a981384caf4598f50c44910d5c4b22d) | `haskell.packages.ghc901.ormolu: 0.3.0.0 -> 0.3.0.1`                         |
| [`65da4ceb`](https://github.com/NixOS/nixpkgs/commit/65da4ceb66d2d7caa4ba513689b2ad6a0d1bf2ac) | `haskellPackages: regenerate package set based on current config`            |
| [`1a74b3d5`](https://github.com/NixOS/nixpkgs/commit/1a74b3d5902357fd77ebc567c97350c0dc275284) | `haskellPackages: stackage-lts 18.10 -> 18.12`                               |
| [`0280f099`](https://github.com/NixOS/nixpkgs/commit/0280f0990add14411bf9f9b722727f2c8b6fdce7) | `all-cabal-hashes: 2021-09-19T21:23:33Z -> 2021-09-29T20:58:23Z`             |
| [`a01157f3`](https://github.com/NixOS/nixpkgs/commit/a01157f37088ec03184f5f2360e8a33f453acf90) | `python38Packages.vispy: 0.8.1 -> 0.9.0`                                     |
| [`cc9e7f0b`](https://github.com/NixOS/nixpkgs/commit/cc9e7f0b047cbf2d9928edc387754c0bccfc525c) | `exim: 4.94.2 -> 4.95`                                                       |
| [`76b7b34c`](https://github.com/NixOS/nixpkgs/commit/76b7b34c1cd7332a089d4d58b726399ea0b036ed) | `scorecard: 2.1.3 -> 2.2.8`                                                  |
| [`e6633282`](https://github.com/NixOS/nixpkgs/commit/e66332826a5b1d19d03535c9305c4477e249e9a9) | `lirc: Set a writable lockdir`                                               |
| [`afb9599b`](https://github.com/NixOS/nixpkgs/commit/afb9599b45e2424e8c91f11fb72912c2770b6141) | `gpsd: 3.23 -> 3.23.1`                                                       |
| [`a02160a2`](https://github.com/NixOS/nixpkgs/commit/a02160a2817db56b47bb91ef3513c34572b5ac0f) | `home-assistant: update component-packages`                                  |
| [`a708db61`](https://github.com/NixOS/nixpkgs/commit/a708db61348a43406ac240efc63c88fd00cfbd83) | `python3Packages.asmog: init at 0.0.6`                                       |
| [`00dc3dcf`](https://github.com/NixOS/nixpkgs/commit/00dc3dcf8bfb3d7806fefa83e1e65d46cd6b5e24) | `fetchFromGitHub: allow forcing fetchGit`                                    |
| [`b9f8421d`](https://github.com/NixOS/nixpkgs/commit/b9f8421d48b77f5982008703375a0d8850b30ff8) | `fetchgithub: allow private repos to use fetchgit`                           |
| [`6f53c067`](https://github.com/NixOS/nixpkgs/commit/6f53c067482743fd68a5beceeb1205fab0ebe4c4) | `fetchgit: add support for netrc file through impure NIX_GIT_SSL_CAINFO env` |
| [`19f4d840`](https://github.com/NixOS/nixpkgs/commit/19f4d840348f79379353d479d6f4def99cbf51c4) | `python38Packages.doc8: 0.9.0 -> 0.9.1`                                      |
| [`8034521f`](https://github.com/NixOS/nixpkgs/commit/8034521fcba7f474cbbe0e441d3d42f5746df8eb) | `python38Packages.apispec: 5.1.0 -> 5.1.1`                                   |
| [`453b0f6b`](https://github.com/NixOS/nixpkgs/commit/453b0f6b6e3c4987716d4fc54a86cf61b67000ba) | `s3cmd: 2.1.0 -> 2.2.0`                                                      |
| [`ec4a1591`](https://github.com/NixOS/nixpkgs/commit/ec4a1591007265384c0f036e265e5e38eff83231) | `transmission: fixes to make one test work again`                            |
| [`56e4a33b`](https://github.com/NixOS/nixpkgs/commit/56e4a33bf3b42491f727ada03c872754159d205c) | `python38Packages.sphinxcontrib-plantuml: 0.21 -> 0.22`                      |
| [`06517475`](https://github.com/NixOS/nixpkgs/commit/06517475069b6d798aab7e8bf9214e0c81c7d06c) | `python3Packages.puremagic: remove patching`                                 |
| [`c313f019`](https://github.com/NixOS/nixpkgs/commit/c313f019748c9bba60ea2b03dd5b9d9e47b01db9) | `python38Packages.puremagic: 1.10 -> 1.11`                                   |
| [`d9b9673f`](https://github.com/NixOS/nixpkgs/commit/d9b9673fb05fc6b51de67da0e6d057d6cf3c9f42) | `python38Packages.maxminddb: 2.1.0 -> 2.2.0`                                 |
| [`49041cd8`](https://github.com/NixOS/nixpkgs/commit/49041cd82eeae4d8413c79a10e46d8a1d9e8c083) | `gnomeExtensions: rename extensionPatches.nix to extensionOverrides.nix`     |
| [`4fce4bfd`](https://github.com/NixOS/nixpkgs/commit/4fce4bfdbde8d57822a9b12949d6b1d2b0319536) | `python3Packages.mautrix: add sumnerevans as maintainer`                     |
| [`e6a9cd96`](https://github.com/NixOS/nixpkgs/commit/e6a9cd966ab68f7d119b95e471b72b35b4446f72) | `python3Packages.mautrix: 0.10.6 -> 0.10.8`                                  |
| [`e2468d4f`](https://github.com/NixOS/nixpkgs/commit/e2468d4fb339db1527d7104ae071c32727aa7d03) | `minikube: 1.23.0 -> 1.23.2`                                                 |
| [`46ac74d0`](https://github.com/NixOS/nixpkgs/commit/46ac74d06b45fec0e66f7dccdbb041b6a9320678) | `kubecfg: 0.20.0 -> 0.21.0`                                                  |
| [`85a188f0`](https://github.com/NixOS/nixpkgs/commit/85a188f0f890826de55fabefb905d46842c28691) | `helmsman: 3.7.3 -> 3.7.5`                                                   |
| [`deed6340`](https://github.com/NixOS/nixpkgs/commit/deed63400fbd9d312769f686d8a307648c2a94c4) | `sslmate: 1.8.0 -> 1.9.0`                                                    |
| [`ba482884`](https://github.com/NixOS/nixpkgs/commit/ba482884f4e3d9c9419d67513c70df2d333eead8) | `traefik: 2.5.2 -> 2.5.3`                                                    |
| [`892f9373`](https://github.com/NixOS/nixpkgs/commit/892f9373701ff5f44772ea7aa1f5f884c6c6b49f) | `firmwareLinuxNonfree: 2021-08-18 -> 2021-09-19`                             |
| [`b81a0ff2`](https://github.com/NixOS/nixpkgs/commit/b81a0ff2562313d0352f68007726737977799b65) | `coredns: 1.8.4 -> 1.8.5`                                                    |
| [`25b9b3b7`](https://github.com/NixOS/nixpkgs/commit/25b9b3b762ed713023ab43b000ae29e1c777f04b) | `multus-cni: 3.7.2 -> 3.8`                                                   |
| [`f1a3e786`](https://github.com/NixOS/nixpkgs/commit/f1a3e78658602afe112308353372a4bc30feff8a) | `hubstaff: 1.6.0-02e625d8 -> 1.6.1-20f4dbb0`                                 |
| [`2de33b71`](https://github.com/NixOS/nixpkgs/commit/2de33b718400ee76eba738cdec846fc25ca4287a) | `gnomeExtensions.tilingGnome: remove unstable in pname`                      |
| [`48064d95`](https://github.com/NixOS/nixpkgs/commit/48064d95d944709a7eb679c0129c424c63c52371) | `gnomeExtensions.screenshot-tool: Fix paths`                                 |
| [`0ce4ae67`](https://github.com/NixOS/nixpkgs/commit/0ce4ae676a817d028af86931ccd4a23f4e9fb4eb) | `gnomeExtensions.brightness-control-using-ddcutil: Fix paths`                |
| [`2c063fe2`](https://github.com/NixOS/nixpkgs/commit/2c063fe250e019a44eba31e4f7857d0e35065b5b) | `gnomeExtensions: add patch framework`                                       |
| [`0ae7a901`](https://github.com/NixOS/nixpkgs/commit/0ae7a901e1e0c4ce965800c7814e80d1e877a059) | `pdfsam-basic: 4.2.3 -> 4.2.6`                                               |