### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ee084c02040e864eeeb4cf4f8538d92f7c675671",
-        "sha256": "1x8amcixdaw3ryyia32pb706vzhvn5whq9n8jin0qcha5qnm1fnh",
+        "rev": "0699530f08290f34c532beedd66046825d9756fa",
+        "sha256": "1845czci6i1jj85mpr2yjvxr8kr9nqmlpimggfb6zxndzyb5n8zx",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/ee084c02040e864eeeb4cf4f8538d92f7c675671.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/0699530f08290f34c532beedd66046825d9756fa.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                          |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`63df91f7`](https://github.com/NixOS/nixpkgs/commit/63df91f789fd973ece46ad9547f6a72ea7dfb231) | `coqPackages.coq-ext-lib: 0.11.3 → 0.11.4`                                              |
| [`c50a069e`](https://github.com/NixOS/nixpkgs/commit/c50a069e69e597f3989fa8f1cf6e41998b271650) | `latte-dock: fix autostart file (#140462)`                                              |
| [`3109ff57`](https://github.com/NixOS/nixpkgs/commit/3109ff5765505dbe1f7f2905ed3f54c62bd0acaa) | `treewide: avoid use of lib.optional with list in inputs`                               |
| [`c8352c07`](https://github.com/NixOS/nixpkgs/commit/c8352c076d58731627feb972343601c6c646d9d7) | `pamixer: unstable-2021-03-29 -> 1.5`                                                   |
| [`18fd76f7`](https://github.com/NixOS/nixpkgs/commit/18fd76f7c77742268ce1840c237a901df3a75c0e) | `pamixer: install using Makefile`                                                       |
| [`ccdde0a8`](https://github.com/NixOS/nixpkgs/commit/ccdde0a882e026a15a5142727bcdf2c95e4b68f2) | `containerd_1_4: 1.4.9 -> 1.4.11`                                                       |
| [`aabceb85`](https://github.com/NixOS/nixpkgs/commit/aabceb8539b694e8711b8632c18f21396aa6f34e) | `containerd: 1.5.5 -> 1.5.7`                                                            |
| [`6b3c9e14`](https://github.com/NixOS/nixpkgs/commit/6b3c9e1400b737ef8e7d1eb4143de11323dec229) | `vscode-extensions.takayama.vscode-qq: init at 1.4.0`                                   |
| [`273251e5`](https://github.com/NixOS/nixpkgs/commit/273251e5930ab072c8105c01233550e3ffcc629f) | `dyff: init at 1.4.3 (#134772)`                                                         |
| [`fdcd3a10`](https://github.com/NixOS/nixpkgs/commit/fdcd3a108465d353c815d58519353bd22cb234a9) | `python3Packages.pep8-naming: remove unused input`                                      |
| [`12795e3a`](https://github.com/NixOS/nixpkgs/commit/12795e3a53ce38cc0e36b293d26a0779978bf8d2) | `gonic: 0.13.1 -> 0.14.0`                                                               |
| [`e22edea5`](https://github.com/NixOS/nixpkgs/commit/e22edea5545a1ec7a1caecae6d92bf5fe009caea) | `k0sctl: 0.10.2 -> 0.10.3`                                                              |
| [`38644421`](https://github.com/NixOS/nixpkgs/commit/38644421367253ce1aa40c052d9d7f38b0f6de05) | `lua-packages: fix getLuaPath and getLuaCPath`                                          |
| [`369dde88`](https://github.com/NixOS/nixpkgs/commit/369dde88d4e1caaed24da16511b3b4b3fbfbff68) | `open-vm-tools: 11.3.0 -> 11.3.5`                                                       |
| [`14aef06d`](https://github.com/NixOS/nixpkgs/commit/14aef06d9b3ad1d07626bdbb16083b83f92dc6c1) | `velero: 1.6.3 -> 1.7.0 (#140434)`                                                      |
| [`b9af3448`](https://github.com/NixOS/nixpkgs/commit/b9af3448c1923e9ed459a9535ff893bea503f085) | `typos: init at 1.1.9 (#140458)`                                                        |
| [`3009b7e5`](https://github.com/NixOS/nixpkgs/commit/3009b7e500faf8b61a30b258ae8e98a0c684f035) | `mhost: init at 0.3.0 (#140455)`                                                        |
| [`ec5455fc`](https://github.com/NixOS/nixpkgs/commit/ec5455fc231160d54b431295e3d0d8b882108dee) | `cmake-language-server: 0.1.2 → 0.1.3`                                                  |
| [`6d7c2d3d`](https://github.com/NixOS/nixpkgs/commit/6d7c2d3db3cb4953eb62dccecfe2884f8b18130e) | `pythonPackages.pygls: 0.9.1 → 0.11.2`                                                  |
| [`249952c4`](https://github.com/NixOS/nixpkgs/commit/249952c49dfe8237b9501ee07903866acfcb9c19) | `python38Packages.pontos: 21.9.1 -> 21.10.0`                                            |
| [`6c814d55`](https://github.com/NixOS/nixpkgs/commit/6c814d55b2014100e061d0fae847eb9fd4db4421) | `materia-kde-theme: 20210624 -> 20210814`                                               |
| [`2ddc335e`](https://github.com/NixOS/nixpkgs/commit/2ddc335e6f32b875e14ad9610101325b306a0add) | `nixos/doc: clean up defaults and examples`                                             |
| [`cd2e9e83`](https://github.com/NixOS/nixpkgs/commit/cd2e9e83e987cce308a76b8e00ccc8d785eca8c5) | `python3Packages.aioesphomeapi: 9.1.2 -> 9.1.4`                                         |
| [`4f762132`](https://github.com/NixOS/nixpkgs/commit/4f762132b048c93605cf24ca51975cfba7245b0b) | `coqPackages.multinomials: fix`                                                         |
| [`3465a9b5`](https://github.com/NixOS/nixpkgs/commit/3465a9b5d2b1cb195fca375849d8ead36977b1e8) | `yascreen: init at 1.86`                                                                |
| [`8467f290`](https://github.com/NixOS/nixpkgs/commit/8467f29068956b7b10d9a6174089295b60e5a704) | `python3Packages.distorm3: enable tests`                                                |
| [`afc60010`](https://github.com/NixOS/nixpkgs/commit/afc60010a65e2f4ee19fba928acd1bb0ba76128e) | `terraform-providers.netlify: 0.4.0 -> 0.6.12`                                          |
| [`0063d3d6`](https://github.com/NixOS/nixpkgs/commit/0063d3d668cf93fcdefa7f4b4778ddc59d588443) | `python3Packages.distorm3: 3.3.4 -> 3.5.2`                                              |
| [`a89400db`](https://github.com/NixOS/nixpkgs/commit/a89400db621a2d657c2adf2dc024065915996250) | `carla: fix --app-name for compatibility with NSM`                                      |
| [`22807730`](https://github.com/NixOS/nixpkgs/commit/228077302ca9cb2f909ffb2f4886385c0343baf7) | `certgraph: init at 20210224`                                                           |
| [`a0306e77`](https://github.com/NixOS/nixpkgs/commit/a0306e7768e470f9ac1525a6df7805e4e4d8e847) | `dismap: init at 0.2`                                                                   |
| [`6c5d4a6e`](https://github.com/NixOS/nixpkgs/commit/6c5d4a6e116fa57903c55a38838e9c8aefd62d15) | `dbeaver: 21.2.1 -> 21.2.2`                                                             |
| [`f18bd6f9`](https://github.com/NixOS/nixpkgs/commit/f18bd6f9192e0f4b78419efe4caaf0fd37a0a346) | `gitlab-runner: 14.3.0 -> 14.3.2`                                                       |
| [`ffab7bf0`](https://github.com/NixOS/nixpkgs/commit/ffab7bf0f51bbe2dd84f277983041a2dc29e93f6) | `gitlab: 14.3.1 -> 14.3.2`                                                              |
| [`3f3dc884`](https://github.com/NixOS/nixpkgs/commit/3f3dc884fb7afa44da6b21fe4c66c3836177d1c4) | `cariddi: init at 1.1`                                                                  |
| [`b88560c0`](https://github.com/NixOS/nixpkgs/commit/b88560c0a6f930df67be368595c3ba2dc2a54a2f) | `shellz: init at 1.6.0`                                                                 |
| [`e74fc39e`](https://github.com/NixOS/nixpkgs/commit/e74fc39e6e9081628d99e8578a59e7fca13fe799) | `mathpix-snipping-tool: 03.00.0050 -> 03.00.0072`                                       |
| [`00c5aa27`](https://github.com/NixOS/nixpkgs/commit/00c5aa27ba8643fc8cecf937a78085ed1f4a9a7f) | `crow-translate: 2.8.4 → 2.8.7`                                                         |
| [`a867c65d`](https://github.com/NixOS/nixpkgs/commit/a867c65d399a48db858656d918d717a2487aa942) | `chia: 1.2.7 -> 1.2.9`                                                                  |
| [`2803b689`](https://github.com/NixOS/nixpkgs/commit/2803b68946db1775a56bde197d870d2a7a2a7bb5) | `python3Packages.whirlpool-sixth-sense: init at unstable-2021-08-22`                    |
| [`d6db403f`](https://github.com/NixOS/nixpkgs/commit/d6db403f9eb6e2608b6c24de8b8eb89c6d6903e6) | `python3Packages.pyflume: 0.7.0 -> 0.7.1`                                               |
| [`5b3750ed`](https://github.com/NixOS/nixpkgs/commit/5b3750eddf86913d944224ada71ecc5069aca4e8) | `cudatext: 1.143.0 → 1.146.0`                                                           |
| [`793bb4bd`](https://github.com/NixOS/nixpkgs/commit/793bb4bd7af9949f9729d277c9bb2a176159b650) | `python3Packages.asyncwhois: 0.3.2 -> 0.4.0`                                            |
| [`9b60174d`](https://github.com/NixOS/nixpkgs/commit/9b60174db20eadfaa1926c1eb048fa6ad78c14cd) | `python3Packages.whodap: init at 0.1.2`                                                 |
| [`6124300b`](https://github.com/NixOS/nixpkgs/commit/6124300ba0da1a72ff1476b6dec21db375bddffa) | `python38Packages.gdown: 3.14.0 -> 4.0.1`                                               |
| [`5487d816`](https://github.com/NixOS/nixpkgs/commit/5487d816c33807920689dfbc8c630f0815869092) | `sad: 0.4.14 -> 0.4.17`                                                                 |
| [`63b5af62`](https://github.com/NixOS/nixpkgs/commit/63b5af623aeceaeb7fc18ba6c1f8bd1b0e9284c2) | `eudev: fix homepage link`                                                              |
| [`19ee8600`](https://github.com/NixOS/nixpkgs/commit/19ee8600029c4810e5cc3b921b244109053833f1) | `calibre-web: allow later unidecode release`                                            |
| [`6d298ca4`](https://github.com/NixOS/nixpkgs/commit/6d298ca46b2dbcfc04a7f56448a1151ca55b82f1) | `octoprint: update override for unidecode`                                              |
| [`c59947fd`](https://github.com/NixOS/nixpkgs/commit/c59947fdd16b526b3e7303e86afd30af254e440d) | `python3Packages.unidecode: enable tests`                                               |
| [`79d7190c`](https://github.com/NixOS/nixpkgs/commit/79d7190c19b89661060102f7f2469b23cc1d46b5) | `python3Packages.unidecode: 1.2.0 -> 1.3.1`                                             |
| [`4b866da2`](https://github.com/NixOS/nixpkgs/commit/4b866da20b8a43764d46280dec118b6c13af198a) | `pjsip: 2.10 -> 2.11.1`                                                                 |
| [`2489084b`](https://github.com/NixOS/nixpkgs/commit/2489084b0592b7ffc8744e8235b008f48f6b1fad) | `krane: init at 2.3.0`                                                                  |
| [`95c8ba90`](https://github.com/NixOS/nixpkgs/commit/95c8ba90a44de597fbb62838a69a7d61f6e8f0c2) | `pgo-client: 4.7.2 -> 4.7.3`                                                            |
| [`6ea41eaa`](https://github.com/NixOS/nixpkgs/commit/6ea41eaabb48dd8401d0d30b85fb7004a615a320) | `redis: 6.2.5 -> 6.2.6`                                                                 |
| [`330b1e08`](https://github.com/NixOS/nixpkgs/commit/330b1e08b8df4e1f0100a0a7810ec3157749e5ee) | `nixos/lib/make-options-doc: implement literalDocBook`                                  |
| [`52a2e413`](https://github.com/NixOS/nixpkgs/commit/52a2e4136e270f9efd6838adb69304fe6d4d431e) | `lib/options: add literalExpression and literalDocBook, deprecate literalExample`       |
| [`f148c3f9`](https://github.com/NixOS/nixpkgs/commit/f148c3f9aecd261d2845b7144918bed70e78fd5c) | `magic-wormhole: add mainProgram meta`                                                  |
| [`6dbccf49`](https://github.com/NixOS/nixpkgs/commit/6dbccf4926c98abe6a2c91fe43198b6a7f08494c) | `qtwebengine: 5.15.5 -> 5.15.6`                                                         |
| [`3cd3914e`](https://github.com/NixOS/nixpkgs/commit/3cd3914eac4881892797d482d238c8eacc0f4a6d) | `python38Packages.mautrix: 0.10.8 -> 0.10.9`                                            |
| [`45ef620a`](https://github.com/NixOS/nixpkgs/commit/45ef620a697965d5f35cd399dbe59fbf7628f24f) | `python3Packages.clvm-rs: 0.1.11 -> 0.1.14`                                             |
| [`917a0cfe`](https://github.com/NixOS/nixpkgs/commit/917a0cfe47bad420a894fe8ca35d7dd95ebb5a7c) | `discourse: Make sure the notification email setting applies`                           |
| [`e3ff6189`](https://github.com/NixOS/nixpkgs/commit/e3ff6189f6aa641e108876de32ad83a542259b60) | `newlib-nano: Init`                                                                     |
| [`e347db2f`](https://github.com/NixOS/nixpkgs/commit/e347db2fb6c807ba1980edc9058a48ab0bfa8a5b) | `prospector: 1.2.0 -> 1.5.1`                                                            |
| [`a2da37b3`](https://github.com/NixOS/nixpkgs/commit/a2da37b3c7ca57cfc286075315a58824d3f7549e) | `python3Packages.pylint-django: 2.4.3 -> 2.4.4`                                         |
| [`2e90ceca`](https://github.com/NixOS/nixpkgs/commit/2e90ceca5f5c6b68cef451f16861e45b69efd883) | `python3Packages.requirements-detector: 0.6 -> 0.7`                                     |
| [`7898c4fe`](https://github.com/NixOS/nixpkgs/commit/7898c4fe83f4cffc8e1c519be1e9d6313a3261cd) | `python3Packages.pep8-naming: 0.11.1 -> 0.12.1`                                         |
| [`5ea6bb83`](https://github.com/NixOS/nixpkgs/commit/5ea6bb839e7bd773f6c995ca6018b68cb8ace7aa) | `newlib: Add parameter for "nano" variant`                                              |
| [`b5cc6075`](https://github.com/NixOS/nixpkgs/commit/b5cc60755857bc98c593c4f0d7fad50707577ba8) | `keystore-explorer: use latest available lts java version to run keystore-explorer`     |
| [`439c13bf`](https://github.com/NixOS/nixpkgs/commit/439c13bf15cd4b57a1c16729b756608d1e3420ca) | `citrix-workspace: Add sources for 21_08_0 plus glib-networking to runtimeDependencies` |
| [`593ee3c2`](https://github.com/NixOS/nixpkgs/commit/593ee3c2426fd6c1ee61c9869afcb3f75e5e84e0) | `comfortaa: 3.101 -> 2021-07-29`                                                        |
| [`60679c15`](https://github.com/NixOS/nixpkgs/commit/60679c15e31924923b5d36810ed1d45debcca80d) | `kwin: unwrap executable name for resource name`                                        |
| [`01cf646d`](https://github.com/NixOS/nixpkgs/commit/01cf646d47a4d141188676d2b5579476a564a652) | `dbeaver: 21.2.0 -> 21.2.1`                                                             |
| [`827b7b96`](https://github.com/NixOS/nixpkgs/commit/827b7b962ce3dac8028f1fdd5a0630869a8fb91c) | `mimic: 1.2.0.2 -> 1.3.0.1`                                                             |
| [`063fde88`](https://github.com/NixOS/nixpkgs/commit/063fde88482a8c78205e16f8dc4d29b3f98857dd) | `polylith: 0.1.0-alpha9 -> 0.2.12-alpha`                                                |