### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f91fec348dd7e6da0bb222c9470c7d1046dcec78",
-        "sha256": "0kl6cz81z0jc6kzpwlbn4r2dpn25sfdvq3jykhbrbx43l4hxkz1k",
+        "rev": "b256715457b6078d729c64bf91596f808a67e28e",
+        "sha256": "1likp7yfr1fdl5yf5qiq3bzcpm378dbn5bbzrng73h81sbjqdy6j",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/f91fec348dd7e6da0bb222c9470c7d1046dcec78.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/b256715457b6078d729c64bf91596f808a67e28e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`b2567154`](https://github.com/NixOS/nixpkgs/commit/b256715457b6078d729c64bf91596f808a67e28e) | `firefox-bin: 92.0 -> 92.0.1`                                                       |
| [`5f9073cc`](https://github.com/NixOS/nixpkgs/commit/5f9073ccc597953f1627d02fa8fa695355502e6a) | `terraform-providers.mkProvider: init (#140465)`                                    |
| [`90e089d9`](https://github.com/NixOS/nixpkgs/commit/90e089d9dd5aba64cd5663d0ec010e17e79dc37f) | `python38Packages.scrapy-splash: 0.7.2 -> 0.8.0`                                    |
| [`a13747dc`](https://github.com/NixOS/nixpkgs/commit/a13747dcac8c36febb533dba67ad7b37c1105dc1) | `mole: init at 2.0.0`                                                               |
| [`0585e3db`](https://github.com/NixOS/nixpkgs/commit/0585e3dbfff262ed537e3dcd9ba80a20609dafe6) | `codeowners: Add myself for NixOS system`                                           |
| [`7ae5d06f`](https://github.com/NixOS/nixpkgs/commit/7ae5d06f096e461997eb92f63781328d75556d20) | `python38Packages.rdflib-jsonld: 0.5.0 -> 0.6.2`                                    |
| [`8faf3aba`](https://github.com/NixOS/nixpkgs/commit/8faf3abafdb31ccb9056b58445ca7fc4610be561) | `python38Packages.packageurl-python: 0.9.4 -> 0.9.6`                                |
| [`739dbd63`](https://github.com/NixOS/nixpkgs/commit/739dbd6347d3eb958f0643fb64841741d1fe487a) | `python3Packages.foxdot: enable darwin build`                                       |
| [`5e770ac3`](https://github.com/NixOS/nixpkgs/commit/5e770ac32fb8aa15e324c5c045665f69121a30a7) | `supercollider: enable build on aarch64-linux`                                      |
| [`075c4922`](https://github.com/NixOS/nixpkgs/commit/075c49224317916f8761a4899436ee9ad47fe502) | `imagemagick: 7.1.0-8 -> 7.1.0-9`                                                   |
| [`22b42b41`](https://github.com/NixOS/nixpkgs/commit/22b42b4110e052000f7569a710b200c5fb33e944) | `python38Packages.pyvesync: 1.4.0 -> 1.4.1`                                         |
| [`dabab908`](https://github.com/NixOS/nixpkgs/commit/dabab90877b98e0c6f54071cce31ca84f9facdb7) | `kratos: update to 0.7.6-alpha.1`                                                   |
| [`c5b4e533`](https://github.com/NixOS/nixpkgs/commit/c5b4e5331f2c97e5ddf4727dc72f27d319250a61) | `vimPlugins.vim-noctu: init at 2015-06-27`                                          |
| [`2deae093`](https://github.com/NixOS/nixpkgs/commit/2deae09349e65de4b40c4259b146ee33ec8761ba) | `vimPlugins: update`                                                                |
| [`4d76247e`](https://github.com/NixOS/nixpkgs/commit/4d76247ef95da191270d18ef8a34683c6826ce21) | `unify-poller: remove default platform`                                             |
| [`47322988`](https://github.com/NixOS/nixpkgs/commit/473229889001f5ebf5dfc164ae14ffe54d3fed7e) | `apache: cleanup, remove ? null, remove extra lib., remove let in, update homepage` |
| [`e9ab5bfe`](https://github.com/NixOS/nixpkgs/commit/e9ab5bfe00c5c0dfa95351a32820acba889ea859) | `autosuspend: init at 4.0.0 (#140532)`                                              |
| [`1c284e75`](https://github.com/NixOS/nixpkgs/commit/1c284e75a8050750a28bde7741cc526f4c3e70a4) | `python38Packages.somecomfort: 0.6.0 -> 0.7.0`                                      |
| [`88c65e2e`](https://github.com/NixOS/nixpkgs/commit/88c65e2e69b4367b00efc8a291117c6d38797149) | `telepresence: 0.108 -> 0.109 (#140580)`                                            |
| [`451c31e5`](https://github.com/NixOS/nixpkgs/commit/451c31e540283edc6ca92b0f8c53ecf4f0489b4b) | `osmium-tool: 1.13.1 → 1.13.2`                                                      |
| [`5476e647`](https://github.com/NixOS/nixpkgs/commit/5476e647e0f0fab15efcdba84175a4543ed0f245) | `libosmium: 2.17.0 → 2.17.1`                                                        |
| [`09568b1f`](https://github.com/NixOS/nixpkgs/commit/09568b1fbe44f02a25806160255fbaa611c13c26) | `emacs2nix: Bump version`                                                           |
| [`45816e7c`](https://github.com/NixOS/nixpkgs/commit/45816e7ca98d07975147e6a5bd5f406ebd54f347) | `dart: 2.13.1 -> 2.14.3`                                                            |
| [`b9126f77`](https://github.com/NixOS/nixpkgs/commit/b9126f77f553974c90ab65520eff6655415fc5f4) | `python38Packages.mypy-boto3-s3: 1.18.53 -> 1.18.54`                                |
| [`f30e4d3f`](https://github.com/NixOS/nixpkgs/commit/f30e4d3f049fbde3f9e93785826e15b0b453158c) | `citrix-workspace: clean up old URLs`                                               |
| [`d97c5555`](https://github.com/NixOS/nixpkgs/commit/d97c5555bc344db68a0cbc5322003e519a067bed) | `@tailwindcss/language-server init at 0.0.4`                                        |
| [`86ad6b52`](https://github.com/NixOS/nixpkgs/commit/86ad6b525104531796b68dda4f76aa5e8fc14193) | `cbqn: remove vendoring using builtin capabilities`                                 |
| [`fc24bb88`](https://github.com/NixOS/nixpkgs/commit/fc24bb88c3550ca9a362727cf14350201b5e2533) | `s6-rc: fix source hash`                                                            |
| [`20bf59c6`](https://github.com/NixOS/nixpkgs/commit/20bf59c69af35e7c794437ce5b001594ccd0800f) | `moonraker: unstable-2021-09-04 -> unstable-2021-09-21 (#139125)`                   |
| [`f048b140`](https://github.com/NixOS/nixpkgs/commit/f048b1401f8246c4a8841d15190ebe7c8f15941a) | `fstar: 2021.09.11 -> 2021.09.30`                                                   |
| [`35dbd1ba`](https://github.com/NixOS/nixpkgs/commit/35dbd1ba876827c587f1a19816ec3156f27cff4c) | `maintainers: add pnmadelaine`                                                      |
| [`b17c1557`](https://github.com/NixOS/nixpkgs/commit/b17c155720092dd04a2be0d096f43dae8c80d46f) | `apacheHttpd: 2.4.49 -> 2.4.50`                                                     |
| [`e7267763`](https://github.com/NixOS/nixpkgs/commit/e7267763b813455cd7a3b08e555efbc61cebc2fe) | `python38Packages.pex: 2.1.50 -> 2.1.51`                                            |
| [`b4981eb8`](https://github.com/NixOS/nixpkgs/commit/b4981eb8e18c5d96e59b94b8b8acb51509ec7ed6) | `earlyoom module: log stderr to journald`                                           |
| [`415724f5`](https://github.com/NixOS/nixpkgs/commit/415724f5f9ae51159d3117dbc3ddbf9ca5eec3c9) | `python38Packages.jupyter_server: 1.11.0 -> 1.11.1`                                 |
| [`c53c69ab`](https://github.com/NixOS/nixpkgs/commit/c53c69ab17cd3997918a3d877e512dabed594fd0) | `nixos: fixes after #136909`                                                        |
| [`30b41c7c`](https://github.com/NixOS/nixpkgs/commit/30b41c7c594d6afbce54fb0bce6335291069442a) | `python38Packages.junos-eznc: 2.6.2 -> 2.6.3`                                       |
| [`1f9c0beb`](https://github.com/NixOS/nixpkgs/commit/1f9c0bebf8c58e71ee56da5ac45b5f536a04b2fd) | `python3Packages.python-lsp-server: 1.2.2 -> 1.2.3`                                 |
| [`2384362c`](https://github.com/NixOS/nixpkgs/commit/2384362ca765da34e4089b0dbb738d2ae0340cf3) | `nixos/gitea: fix eval after #136909`                                               |
| [`9f9e3223`](https://github.com/NixOS/nixpkgs/commit/9f9e32238b200716a622bd743e6859495aa83db1) | `mautrix-telegram: add `prometheus-client` for metrics`                             |
| [`b413827b`](https://github.com/NixOS/nixpkgs/commit/b413827ba05fd0f8e7c6c355b79678ecf6838017) | `erlang: 24.1.1 -> 24.1.2`                                                          |
| [`446145f5`](https://github.com/NixOS/nixpkgs/commit/446145f5fb0cce392f1a35509dff37d5aa4973e5) | `hci: Cache on hydra`                                                               |
| [`8377a7bc`](https://github.com/NixOS/nixpkgs/commit/8377a7bca967dba811899164d4218d1d4a24b483) | `lib: add list of supported systems (#140428)`                                      |
| [`a2a0a58f`](https://github.com/NixOS/nixpkgs/commit/a2a0a58f7c6c3d6f1174524333c078052916841f) | `less: improve default settings (#139988)`                                          |
| [`6565732b`](https://github.com/NixOS/nixpkgs/commit/6565732b630cad18815a9521ae9db542fca947e8) | `python38Packages.pylast: 4.2.1 -> 4.3.0`                                           |
| [`e7c126fb`](https://github.com/NixOS/nixpkgs/commit/e7c126fba7b1b1ecb82a3e469b20d9c0f8b159d4) | `intel-media-driver: add comment to patch`                                          |
| [`34f9123f`](https://github.com/NixOS/nixpkgs/commit/34f9123fa10121f355cd3b77dcf9b8d0e97554fb) | `sbt-extras: 2021-09-15 → 2021-09-24`                                               |
| [`671b2b26`](https://github.com/NixOS/nixpkgs/commit/671b2b2647b9de6db391c0dbc2c1b790e369bed2) | `python39Packages.google-cloud-bigquery-datatransfer: add missing dep`              |
| [`d852da30`](https://github.com/NixOS/nixpkgs/commit/d852da30d791df2be15c0981fff4435aa01f9d18) | `oh-my-zsh: 2021-09-22 → 2021-10-05`                                                |
| [`23754c1a`](https://github.com/NixOS/nixpkgs/commit/23754c1a1c3b690e80d6b0eed9ce295df751a1d8) | `python3Packages.sagemaker: 2.59.6 -> 2.59.7`                                       |
| [`57b618a2`](https://github.com/NixOS/nixpkgs/commit/57b618a2a9d2957778e1af867d0ab6a01a1dc9ff) | `awscli: 1.20.31 -> 1.20.54`                                                        |
| [`78dcd964`](https://github.com/NixOS/nixpkgs/commit/78dcd964805f09e3f3023228163cb329776c77df) | `python3Packages.boto3: 1.18.31 -> 1.18.54`                                         |
| [`c3604d38`](https://github.com/NixOS/nixpkgs/commit/c3604d38199adface755c42570a422f9853c41a7) | `python3Packages.botocore: 1.21.31 -> 1.21.54`                                      |
| [`a4b0e304`](https://github.com/NixOS/nixpkgs/commit/a4b0e3042b33c07f0fb8f6eaf4e69c0cf8520e46) | `ocamlPackages.twt: fix build`                                                      |
| [`7d01ca28`](https://github.com/NixOS/nixpkgs/commit/7d01ca28b55e720107717bd98474037dc5e982a8) | `python38Packages.exchangelib: 4.5.1 -> 4.5.2`                                      |
| [`a7c3d42c`](https://github.com/NixOS/nixpkgs/commit/a7c3d42c47095462c9af0258b452fe2ee996c561) | `slack: 4.19.x -> 4.20.0`                                                           |
| [`7aaf9806`](https://github.com/NixOS/nixpkgs/commit/7aaf9806c752e76cc60a0dff3fe704d627161f4b) | `trilium: 0.47.7 -> 0.47.8`                                                         |
| [`248936ea`](https://github.com/NixOS/nixpkgs/commit/248936ea5700b25cfa9b7eaf8abe13a11fe15617) | `llvmPackages_13.compiler-rt: disable libfuzzer for aarch64`                        |
| [`1d32ab2a`](https://github.com/NixOS/nixpkgs/commit/1d32ab2a57a0e598ab76257816076872eb4e250f) | `python38Packages.emoji: 1.5.2 -> 1.6.0`                                            |
| [`b7f5baaf`](https://github.com/NixOS/nixpkgs/commit/b7f5baafb05655d0a357e75a6b90b09888ef4b5b) | `phpPackages.composer: 2.1.5 -> 2.1.8`                                              |
| [`d0edc6a2`](https://github.com/NixOS/nixpkgs/commit/d0edc6a240ee8f3be4dfbb40d75af26155d7c951) | `oil: 0.9.2 -> 0.9.3`                                                               |
| [`bdb28b80`](https://github.com/NixOS/nixpkgs/commit/bdb28b80e10a2322a5f55cfc722e39e6c1ed57b8) | `citrix-workspace: 21.08.0 -> 21.09.0`                                              |
| [`cbd4fbd6`](https://github.com/NixOS/nixpkgs/commit/cbd4fbd6cee7c6af6b1fb0383dd1b55ca0b982d4) | `python3Packages.vt-py: 0.7.4 -> 0.7.5`                                             |
| [`7fafbcfa`](https://github.com/NixOS/nixpkgs/commit/7fafbcfae42d0b523100bf43f7ed1d23d7436606) | `python3Packages.pydaikin: 2.4.4 -> 2.6.0`                                          |
| [`74430471`](https://github.com/NixOS/nixpkgs/commit/74430471280817626e0f386bdb648df4e939f69b) | `python3Packages.regenmaschine: 3.1.5 -> 3.2.0`                                     |
| [`d0c32351`](https://github.com/NixOS/nixpkgs/commit/d0c3235111a9837f310cdd40c2aa5e94372a0a28) | `tree-sitter: update grammars`                                                      |
| [`6575fff6`](https://github.com/NixOS/nixpkgs/commit/6575fff60f7ca5371ae8796415a98d0ef9256a11) | `vscode-utils: fix configure and build phase`                                       |
| [`81177b2f`](https://github.com/NixOS/nixpkgs/commit/81177b2f50f91ab3716d95d25b3bd7e9fbd875aa) | `python38Packages.exchangelib: 4.5.1 -> 4.5.2`                                      |
| [`6b3af966`](https://github.com/NixOS/nixpkgs/commit/6b3af966b4100ae385e7fd15a608ad32646e3df4) | `openexr_3: 3.1.1 -> 3.1.2`                                                         |
| [`746f9e72`](https://github.com/NixOS/nixpkgs/commit/746f9e72d8c64e18f9ddc2591af23adc52cc44c6) | `exploitdb: clean up bin directory`                                                 |
| [`9ffb86d9`](https://github.com/NixOS/nixpkgs/commit/9ffb86d9df4c8168870b0661c92f6f0d1cc1245a) | `deno: 1.14.2 -> 1.14.3`                                                            |
| [`dd229fd9`](https://github.com/NixOS/nixpkgs/commit/dd229fd9e8039499f4400996a0ff7ab80cc60882) | `python39Packages.ansible-lint: 5.0.8 -> 5.2.0`                                     |
| [`d1131d3e`](https://github.com/NixOS/nixpkgs/commit/d1131d3e12c157473e4d823b0a847242908e13e0) | `yle-dl: 20210808 -> 20210917`                                                      |
| [`939ea021`](https://github.com/NixOS/nixpkgs/commit/939ea02104e5036bd5d76e9417b24b052b1a20c0) | `python3Packages.stestr: 3.2.0 -> 3.2.1`                                            |
| [`8c611f25`](https://github.com/NixOS/nixpkgs/commit/8c611f2555680b7a2e1502f0a6e5e50ad5a16b79) | `python3Packages.proto-plus: 1.19.0 -> 1.19.2`                                      |
| [`893647c9`](https://github.com/NixOS/nixpkgs/commit/893647c91e133903254fd9bfefdd9e80740cbcef) | `android-studio-canary: 2021.1.1.12 → 2021.1.1.13`                                  |
| [`342267b0`](https://github.com/NixOS/nixpkgs/commit/342267b0f0ef6d4bc62394ebdf4dea4089f57e7e) | `httplz: 1.9.2 -> 1.12.1`                                                           |
| [`9b31a0ee`](https://github.com/NixOS/nixpkgs/commit/9b31a0eeb0bf3ab78e165ae771b3d2701f6c9bd3) | `rdma-core: 36.0 -> 37.0`                                                           |
| [`fa991358`](https://github.com/NixOS/nixpkgs/commit/fa9913589a5b06e0f6c1f302789948547912c988) | `ucx: 1.11.1 -> 1.11.2`                                                             |
| [`c301c199`](https://github.com/NixOS/nixpkgs/commit/c301c1995e118c86308ed61359e45c96a741fac9) | `command-not-found: remove NIX_AUTO_INSTALL`                                        |
| [`50c8c208`](https://github.com/NixOS/nixpkgs/commit/50c8c2083a6e77c18afeea9bf657b71757332561) | `fishPlugins.done: 1.16.3 -> 1.16.5`                                                |
| [`b533f012`](https://github.com/NixOS/nixpkgs/commit/b533f012ed55810268b4c71a38ecbb77e78cd9f5) | `solaar: add support for tray icon`                                                 |
| [`9c953d5d`](https://github.com/NixOS/nixpkgs/commit/9c953d5daa52647933f3b8edc444d4e6f98f76cd) | `pipewire: fix build on AArch64`                                                    |
| [`266f7b3a`](https://github.com/NixOS/nixpkgs/commit/266f7b3a25e611592c70c04451a48c9866f195bd) | `python3Packages.werkzeug: disable failing test`                                    |
| [`6831a11f`](https://github.com/NixOS/nixpkgs/commit/6831a11f2f52abf216819dfb7d376da4e75f81c6) | `intel-gmmlib: add SuperSandro2000 as maintainer`                                   |
| [`f98f701e`](https://github.com/NixOS/nixpkgs/commit/f98f701ea2b76ceccea6f24fbcf7456470e5cb03) | `intel-media-driver: fix i686 build, add SuperSandro2000 as maintainer`             |
| [`8c9b5efb`](https://github.com/NixOS/nixpkgs/commit/8c9b5efb9428c136f6b89dce0d60d31463e49484) | `infracost: 0.9.6 -> 0.9.8`                                                         |
| [`7d0c5d33`](https://github.com/NixOS/nixpkgs/commit/7d0c5d3313b3dda27a70cdfd8efcd3e07925a797) | `python3Packages.testfixtures: 6.18.1 -> 6.18.3`                                    |
| [`7b5f9efb`](https://github.com/NixOS/nixpkgs/commit/7b5f9efb581ccbf2ab2558ea6503217a7ad08685) | `postgresqlPackages.pg_repack: 1.4.6 -> 1.4.7`                                      |
| [`7e98a25a`](https://github.com/NixOS/nixpkgs/commit/7e98a25a99ebf92dbe1146971a4dd25dd3a553e0) | `ytcc: 2.4.1 -> 2.4.2`                                                              |
| [`a09db7d6`](https://github.com/NixOS/nixpkgs/commit/a09db7d6da9f0a0bc30b6dfaadd8433871b7d941) | `libpsl: disable valgrind tests on aarch64(-linux)`                                 |
| [`48293bd6`](https://github.com/NixOS/nixpkgs/commit/48293bd6b6b791b9af745e9b7b94a6856e279fa0) | `lib/types: Make types.anything merge functions`                                    |
| [`224019bd`](https://github.com/NixOS/nixpkgs/commit/224019bd1c328977ab91bd890ae24db94ade9a13) | `imagemagick: unbreak for aarch64`                                                  |
| [`cdfbd9ec`](https://github.com/NixOS/nixpkgs/commit/cdfbd9ecdc2fb31eced9cc424562a9b0d2f8545b) | `nexus: 3.30.0-01 -> 3.32.0-03`                                                     |
| [`14cc7d7f`](https://github.com/NixOS/nixpkgs/commit/14cc7d7fec6785c312c5d7f3a276df9500c4d742) | `ums: 9.4.2 -> 10.12.0`                                                             |
| [`2549800a`](https://github.com/NixOS/nixpkgs/commit/2549800a1a83c7fa6f639e915545042667c98789) | `compiler-rt: cont. remove <cyclades.h> from libsanitizer`                          |
| [`b88fce90`](https://github.com/NixOS/nixpkgs/commit/b88fce906f423af9fa8b13af202511d98256a9fa) | `mesa: 21.2.2 -> 21.2.3`                                                            |
| [`4b8bd410`](https://github.com/NixOS/nixpkgs/commit/4b8bd41060e72e6593131a52b915dc37b3f0c0a6) | `nixos/networkd: added IAID, DUIDType and DUIDRawData to DHCPv6 section`            |
| [`8941dd6c`](https://github.com/NixOS/nixpkgs/commit/8941dd6cc8348bb06d52749cb1f7292c8f47c290) | `pythonPackages.sh: disable flaky fd_leak test`                                     |
| [`fb106ee0`](https://github.com/NixOS/nixpkgs/commit/fb106ee08b57b61378519750753ee9dcc1ac9e19) | `libomxil-bellagio: fix build failures against -fno-common compiler`                |
| [`241c3e0b`](https://github.com/NixOS/nixpkgs/commit/241c3e0b3f193e8696038aa650e364aafcfd06c6) | `imagemagick: add build option for JPEG XL image format`                            |