### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "01bd5f8e0dc866e28808bd6acc6e1fe65e08cf34",
-        "sha256": "0nr05vhb95svka442hrkiqyfcqqc1nbivshb0hxr4bbbcyfclvas",
+        "rev": "40f95ae12ac630b76e8f4aa2d378fd2f2a959ff5",
+        "sha256": "058rsw5fdk90bnl51b40lfnsl9w104gxplpyww7n3gjxp8w9frh9",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/01bd5f8e0dc866e28808bd6acc6e1fe65e08cf34.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/40f95ae12ac630b76e8f4aa2d378fd2f2a959ff5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                            |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`60d3ef04`](https://github.com/NixOS/nixpkgs/commit/60d3ef048401840d0a633c046e293c78fef29cb8) | `lib.systems.supported.tier3: add aarch64-darwin`                         |
| [`712755f3`](https://github.com/NixOS/nixpkgs/commit/712755f36e624193415d957c38d52b2a13e19bf3) | `sumneko-lua-language-server: 2.3.6 -> 2.4.1`                             |
| [`d9e912d3`](https://github.com/NixOS/nixpkgs/commit/d9e912d3672688c968a74380efde13474c5a302e) | `pantheon.switchboard-plug-power: fix crash`                              |
| [`50bf0752`](https://github.com/NixOS/nixpkgs/commit/50bf075202f773a18227c8e19872317fa85953a8) | `firefox-bin: 92.0.1 -> 93.0`                                             |
| [`e4574610`](https://github.com/NixOS/nixpkgs/commit/e4574610ca25c4c69e97f57de02acc2a484154ba) | `firefox-esr-78: 78.14.0esr -> 78.15.0esr`                                |
| [`1edb8c96`](https://github.com/NixOS/nixpkgs/commit/1edb8c9622ea3a4157e27ce6577c4590d11aaaee) | `firefox-esr-91: 91.1.0esr -> 91.2.0esr`                                  |
| [`7dfcaf5e`](https://github.com/NixOS/nixpkgs/commit/7dfcaf5e73feebe12606dbc4c08128af75797fa4) | `firefox: 92.0.1 -> 93.0`                                                 |
| [`a23ef6cb`](https://github.com/NixOS/nixpkgs/commit/a23ef6cb4e95c2d56b623211a19ff12df2fb8724) | `python38Packages.pyenchant: 3.2.1 -> 3.2.2`                              |
| [`cc3b147e`](https://github.com/NixOS/nixpkgs/commit/cc3b147ed182a6cae239348ef094158815da14ae) | `nixos/lemmy: init`                                                       |
| [`e8409249`](https://github.com/NixOS/nixpkgs/commit/e8409249d9b3cb3c6944c028203c0fd7a99eb382) | `hci: Fix hydraPlatforms`                                                 |
| [`53390772`](https://github.com/NixOS/nixpkgs/commit/53390772ca02249937ea0c5fe7bb2f6503bb490f) | `top-level/release-r.nix: init Hydra job set for rPackages`               |
| [`5f3fee29`](https://github.com/NixOS/nixpkgs/commit/5f3fee29e2637c0449aeaf5ddae1d97e79b91738) | `vieb: use latest electron`                                               |
| [`7e26b36f`](https://github.com/NixOS/nixpkgs/commit/7e26b36f7a51ef422565d1476c52a93a868541f1) | `raylib: add changelog`                                                   |
| [`138b068c`](https://github.com/NixOS/nixpkgs/commit/138b068c1a5066cd24f8c14e3cd2db20fd4d7415) | `retroshare: update homepage`                                             |
| [`56db7926`](https://github.com/NixOS/nixpkgs/commit/56db7926f08a7b70f9e867ce2b9b6bfbbb1d08fd) | `python38Packages.google-cloud-container: 2.8.0 -> 2.8.1`                 |
| [`b16c74ab`](https://github.com/NixOS/nixpkgs/commit/b16c74abd3b149b09613629219716202c5436427) | `awscli2: 2.2.39 -> 2.2.40 (#139020)`                                     |
| [`b862bde8`](https://github.com/NixOS/nixpkgs/commit/b862bde8b055a3894acc87eeac058ade0ccc007b) | `ocl-icd: update platforms, remove outdated postPatch (#137342)`          |
| [`f35a2f5f`](https://github.com/NixOS/nixpkgs/commit/f35a2f5fdb2ca18b2c4a971c0462c160d07bb7ba) | `python38Packages.javaproperties: 0.8.0 -> 0.8.1`                         |
| [`e6b118a2`](https://github.com/NixOS/nixpkgs/commit/e6b118a209c05ba11bbb0cd09322a1275fa64bb7) | `python38Packages.google-crc32c: 1.2.0 -> 1.3.0`                          |
| [`6a3f62b1`](https://github.com/NixOS/nixpkgs/commit/6a3f62b11b3e8ed156c60e778bd61dfe0702c136) | `python38Packages.google-cloud-runtimeconfig: 0.32.5 -> 0.32.6`           |
| [`beafc415`](https://github.com/NixOS/nixpkgs/commit/beafc415378f72565daf76369388d99ab2fb6d01) | `python38Packages.google-cloud-speech: 2.9.1 -> 2.9.3`                    |
| [`22849ce3`](https://github.com/NixOS/nixpkgs/commit/22849ce37bcd5c2e2f20946869c29a4a6bf65c24) | `python38Packages.google-cloud-spanner: 3.11.0 -> 3.11.1`                 |
| [`471c673d`](https://github.com/NixOS/nixpkgs/commit/471c673d716fc0695557e302d18236cee2f0d1a4) | `grafana: 8.1.5 -> 8.1.6`                                                 |
| [`5ac32013`](https://github.com/NixOS/nixpkgs/commit/5ac32013ca5f58863e1846621c808c4d2819efcd) | `steam: 1.0.0.70 -> 1.0.0.72`                                             |
| [`ef5e8cea`](https://github.com/NixOS/nixpkgs/commit/ef5e8cead5da6a417adb74b3a72ad4dee09ac1af) | `wio: update repository`                                                  |
| [`8a6c04cb`](https://github.com/NixOS/nixpkgs/commit/8a6c04cb8c9a4b78d55737a24a0972bbc88007b6) | `certbot: 1.19.0 -> 1.20.0`                                               |
| [`7e5136fc`](https://github.com/NixOS/nixpkgs/commit/7e5136fcc483af9ca14e3655c1a38bc056b6e26e) | `steamPackages.steam-runtime: 0.20210630.0 -> 0.20210906.1`               |
| [`66cada79`](https://github.com/NixOS/nixpkgs/commit/66cada7957be0879f630772dd4dc0572ea0ac876) | `python38Packages.azure-synapse-spark: 0.6.0 -> 0.7.0`                    |
| [`6ce13375`](https://github.com/NixOS/nixpkgs/commit/6ce13375ce2b29dfccecf2aa424b56cff00fbd8c) | `python38Packages.azure-synapse-artifacts: 0.8.0 -> 0.9.0`                |
| [`c445a64a`](https://github.com/NixOS/nixpkgs/commit/c445a64a28862d94100db04cfde18e3824abf950) | `vscode-extensions.llvm-vs-code-extensions.vscode-clangd: init at 0.1.13` |
| [`db26b5ce`](https://github.com/NixOS/nixpkgs/commit/db26b5ce1769792951df844b193ee531013cc18e) | `python3Packages.class-registry: make alias of phx-class-registry`        |
| [`8b77d991`](https://github.com/NixOS/nixpkgs/commit/8b77d991b6f478ccbd803870c7708a2266a85c38) | `.github/workflows/periodic-merge: move stable merges to 24h cycle`       |
| [`7292fce5`](https://github.com/NixOS/nixpkgs/commit/7292fce53173722e81cf517a614e3ab2c86f72f6) | `python3Packages.aioesphomeapi: 9.1.4 -> 9.1.5`                           |
| [`f4c69e19`](https://github.com/NixOS/nixpkgs/commit/f4c69e198ce8a8208995e43133d4c32d2045a587) | `nixos/bitlbee: switched to systemd DynamicUser`                          |
| [`31790c81`](https://github.com/NixOS/nixpkgs/commit/31790c81dcffee8c267cbc01f16938497ed172af) | `nixos: make setgid wrappers root-owned`                                  |
| [`6f7ab306`](https://github.com/NixOS/nixpkgs/commit/6f7ab306eff4a6d093233d482c1b48d6a9e9e07a) | `gscan2pdf: 2.12.1 → 2.12.3`                                              |
| [`b5dcad8b`](https://github.com/NixOS/nixpkgs/commit/b5dcad8b941aa6caaeb445f7c695a10aae5adbc2) | `perlPackages.PDFAPI2: 2.038 → 2.042`                                     |
| [`58e6a6b6`](https://github.com/NixOS/nixpkgs/commit/58e6a6b6ea260596760ebfcbbed960e8a039c57e) | `perlPackages.PDFBuilder: 3.022 → 3.023`                                  |
| [`70517278`](https://github.com/NixOS/nixpkgs/commit/70517278f143d7fe9217da4871e2daecb546293d) | `perlPackages.ImagePNGLibpng: 0.56 → 0.57`                                |
| [`10ba9839`](https://github.com/NixOS/nixpkgs/commit/10ba9839185513c5d973c50fed7ffd4c618e7732) | `perlPackages.GraphicsTIFF: 9 → 16`                                       |
| [`4d440e90`](https://github.com/NixOS/nixpkgs/commit/4d440e9089750762b8060abbd3264e15155de8a6) | `mariadb: remove broken symlink`                                          |
| [`d1333319`](https://github.com/NixOS/nixpkgs/commit/d1333319d2aac890d63a1b034c4c0956bc0d495b) | `ligolo-ng: init at 0.1`                                                  |