### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ea4524e6cc7761c3cc271233fa97b5e7473f760a",
-        "sha256": "1an68i4hlk1hyds9y6n513kybrk8gsgcp81frs4x3a726ls1hrwj",
+        "rev": "6755a884b24038a73dd4c8022dbb05375feef0a7",
+        "sha256": "1jxc2mmgs8bll8vpzl23ds2ppr4fdza77b1m1748qfi3wv7bs39k",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/ea4524e6cc7761c3cc271233fa97b5e7473f760a.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/6755a884b24038a73dd4c8022dbb05375feef0a7.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                             |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`9a76986e`](https://github.com/NixOS/nixpkgs/commit/9a76986ee0d46ea8074c9a8992df531dd90ac261) | `foot: cache stimuliFile more aggressively`                                |
| [`6bfc5e94`](https://github.com/NixOS/nixpkgs/commit/6bfc5e94f60751aaf5f83e3ffad2cbf51afc9a98) | `foot: 1.9.0 -> 1.9.2`                                                     |
| [`40fd8c9c`](https://github.com/NixOS/nixpkgs/commit/40fd8c9c24980dbb38769b2544ea318ab175761c) | `oh-my-zsh: 2021-10-05 -> 2021-10-06`                                      |
| [`bd47be3c`](https://github.com/NixOS/nixpkgs/commit/bd47be3c865302c04d20263bdda47e56879e099c) | `godns: init at 2.5`                                                       |
| [`cdaf4b12`](https://github.com/NixOS/nixpkgs/commit/cdaf4b1290088c1aec6d8508c7c3020a0d5ef3f3) | `prisma-engines: add support for aarch64-linux`                            |
| [`98cc5c28`](https://github.com/NixOS/nixpkgs/commit/98cc5c28a4fb95b89d7f8cc08702e115798d914b) | `python38Packages.mypy-boto3-s3: 1.18.55 -> 1.18.56`                       |
| [`604e3c90`](https://github.com/NixOS/nixpkgs/commit/604e3c90a95b7b89fd13c0663629cf148006d8d2) | `skopeo: 1.4.1 -> 1.5.0`                                                   |
| [`39ca1674`](https://github.com/NixOS/nixpkgs/commit/39ca16748a73717cc29bdeae262f40f6f6a2da94) | `bluejeans-gui: fixup for #140837 getting version from upstream (#140852)` |
| [`5323bc0f`](https://github.com/NixOS/nixpkgs/commit/5323bc0f144890c23915e8d54d996a5cff97a05c) | `nixUnstable: pre20211001 -> pre20211006`                                  |
| [`713e08cd`](https://github.com/NixOS/nixpkgs/commit/713e08cdc5e0cd7317aff73d3227b5856248b65c) | `ouch: 0.1.5 -> 0.2.0`                                                     |
| [`fdf500dd`](https://github.com/NixOS/nixpkgs/commit/fdf500dd7f1413af9430c5f92ee7f17cce0319a3) | `electron_15: 15.1.0 -> 15.1.1`                                            |
| [`81fa0bab`](https://github.com/NixOS/nixpkgs/commit/81fa0babbacd5070166e882af40772d33eab5cbe) | `Remove changlinli from rstudio maintainers list`                          |
| [`0b6148fa`](https://github.com/NixOS/nixpkgs/commit/0b6148fae9e2fb8e849591aace726de769051241) | `prometheus-openvpn-exporter: mark as broken`                              |
| [`9fea6d4c`](https://github.com/NixOS/nixpkgs/commit/9fea6d4c8551b7c8783f23e011a2ba113c95d0dd) | `nixos/prometheus: systemd unit hardening of exporters`                    |
| [`a1b1b360`](https://github.com/NixOS/nixpkgs/commit/a1b1b360dba4da446096c56cb9613d06b3434c41) | `python3Packages.pubnub: 5.3.1 -> 5.4.0`                                   |
| [`cb907c59`](https://github.com/NixOS/nixpkgs/commit/cb907c594ad9764bc040257f3f8d2b349ed1c3af) | `bluejeans-gui: fix version fetching in update script (#140837)`           |
| [`4c5d2704`](https://github.com/NixOS/nixpkgs/commit/4c5d2704f1096e70c344b81b86f79de0947d6b70) | `python3Packages.dask-jobqueue: fix build`                                 |
| [`9bd53ad9`](https://github.com/NixOS/nixpkgs/commit/9bd53ad913d38b842b8fda93e156a8d48664b9f3) | `picard: 2.6.3 -> 2.6.4`                                                   |
| [`5791d818`](https://github.com/NixOS/nixpkgs/commit/5791d8184f1ba7d641bae730e15be5d0990bf934) | `python3Packages.clifford: 1.3.1 -> 1.4.0`                                 |
| [`fb559de7`](https://github.com/NixOS/nixpkgs/commit/fb559de7a7a6b54bd901b4f39e79c3c82d7fe5f0) | `maintainers: add yinfeng`                                                 |
| [`404ecd73`](https://github.com/NixOS/nixpkgs/commit/404ecd73d9db1918e98410a9027aa827bbc412df) | `cbqn: update version string`                                              |
| [`077f0239`](https://github.com/NixOS/nixpkgs/commit/077f0239d1ba623b0ba052f7d0eea5748dbc515a) | `bqn: 0.0.0+unstable=2021-10-01 -> 0.pre+unstable=2021-10-06`              |
| [`3a3ad7eb`](https://github.com/NixOS/nixpkgs/commit/3a3ad7ebafe50d84ff04b8e1ae510c8df54a2747) | `dbqn: update version format`                                              |
| [`3b4b464a`](https://github.com/NixOS/nixpkgs/commit/3b4b464af28539006080860c5fd70c4222afe0c5) | `home-assistant: 2021.9.7 -> 2021.10.0`                                    |
| [`b4882469`](https://github.com/NixOS/nixpkgs/commit/b48824692091f00eda0d9308bb60dd764effb8a9) | `python3Packages.twilio: 6.56.0 -> 7.1.0`                                  |
| [`51b046a8`](https://github.com/NixOS/nixpkgs/commit/51b046a8e41a3e5dba4fdf40473ac849f5ecf31e) | `python3Packages.zwave-js-server-python: 0.31.1 -> 0.31.3`                 |
| [`b2d385c0`](https://github.com/NixOS/nixpkgs/commit/b2d385c0dac97f694227298ffbb703263c2787cd) | `python3Packages.surepy: 0.7.1 -> 0.7.2`                                   |
| [`7732603f`](https://github.com/NixOS/nixpkgs/commit/7732603f3e903256ca9506bacbc1adbb12051d99) | `python3Packages.streamlabswater: 0.3.2 -> 1.0.1`                          |
| [`823e3f72`](https://github.com/NixOS/nixpkgs/commit/823e3f723f676de77e513958b22e4680fc3f0334) | `python3Packages.pypoint: 2.1.0 -> 2.2.0`                                  |
| [`348f2a9c`](https://github.com/NixOS/nixpkgs/commit/348f2a9c6cc3b50bcada21cca208357e37c9638f) | `python3Packages.pycarwings2: 2.11 -> 2.12`                                |
| [`cc31d945`](https://github.com/NixOS/nixpkgs/commit/cc31d94514110f6e2e91d547199dc32f4a42021f) | `python3Packages.pyatmo: 6.0.0 -> 6.1.0`                                   |
| [`4540d8c3`](https://github.com/NixOS/nixpkgs/commit/4540d8c3a77750e40474ee3e77ec43a29a09d3d3) | `python3Packages.netdisco: 2.9.0 -> 3.0.0`                                 |
| [`5981b3c7`](https://github.com/NixOS/nixpkgs/commit/5981b3c7ae04ff39e427730954d8c1c253993243) | `python3Packages.bellows: 0.27.0 -> 0.28.0`                                |
| [`f700a92d`](https://github.com/NixOS/nixpkgs/commit/f700a92d5c2b307c14ff2610ebfdfa0e98df2e16) | `nixos/qemu-vm: quote QEMU_NET_OPTS`                                       |
| [`60e731d1`](https://github.com/NixOS/nixpkgs/commit/60e731d1ceb7343b1d137afe6b09f3f6409d701b) | `nixos/qemu-vm: fix running VM with `QEMU_NET_OPTS``                       |
| [`eb700218`](https://github.com/NixOS/nixpkgs/commit/eb70021803f16d1cf8c4d20aa565d660ee1580b5) | `eureka-ideas: init at 1.8.1`                                              |
| [`b24904cf`](https://github.com/NixOS/nixpkgs/commit/b24904cf27c918f388168c60e4b2ae84e78424b4) | `python3Packages.aioshelly: 1.0.1 -> 1.0.2`                                |
| [`10e0d2bd`](https://github.com/NixOS/nixpkgs/commit/10e0d2bd66df608abd9ac773089a79c9f5b93ccb) | `python3Packages.aiohue: 2.6.2 -> 2.6.3`                                   |
| [`45a9a24a`](https://github.com/NixOS/nixpkgs/commit/45a9a24aee46ede11303cb79c9a1086b828c3673) | `python3Packages.python-smarttub: 0.0.25 -> 0.0.27`                        |
| [`3e02d644`](https://github.com/NixOS/nixpkgs/commit/3e02d644758f3e17df129712eb098539aa0f6688) | `python3Packages.pyvicare: 2.8.1 -> 2.9.1`                                 |
| [`a9c0e1bf`](https://github.com/NixOS/nixpkgs/commit/a9c0e1bfed012fe94e5b823903f50516567a504c) | `home-assistant: remove pyjwt override`                                    |
| [`a152153e`](https://github.com/NixOS/nixpkgs/commit/a152153eede05936735750196ecfebd4dcc4d238) | `home-assistant: remove pylast override`                                   |
| [`fafec6c3`](https://github.com/NixOS/nixpkgs/commit/fafec6c3be309eff454fbca8a22b8ac78eb957db) | `home-assistant: remove async-upnp-client override`                        |
| [`85e40f1b`](https://github.com/NixOS/nixpkgs/commit/85e40f1bb55975af58a027158c62350143c0a3cb) | `python3Packages.ciso8601: 2.1.3 -> 2.2.0`                                 |
| [`5e3cd48b`](https://github.com/NixOS/nixpkgs/commit/5e3cd48be1bd75cda25665ea747142a6a484e48e) | `python3Packages.python-tado: 0.11.0 -> 0.12.0`                            |
| [`733ada7a`](https://github.com/NixOS/nixpkgs/commit/733ada7a611a2a3841b9b9a27be5578295e9f52e) | `python3Packages.airthings: init at 0.0.1`                                 |
| [`ef2d72a5`](https://github.com/NixOS/nixpkgs/commit/ef2d72a577ac825cee1e099ad5b53ce28d04a8cc) | `python3Packages.pyatmo: 5.2.3 -> 6.0.0`                                   |
| [`5c46b5e3`](https://github.com/NixOS/nixpkgs/commit/5c46b5e3f53ef5144eb8cf9f637cc4f2f6dd4aa7) | `python3Packages.aiohue: 2.6.1 -> 2.6.2`                                   |
| [`774e6008`](https://github.com/NixOS/nixpkgs/commit/774e600897042cf44651150175adaade423471d3) | `python3Packages.aioshelly: 0.6.4 -> 1.0.1`                                |
| [`0773deee`](https://github.com/NixOS/nixpkgs/commit/0773deee07d36acd0b1ab9d4b9117fb340597598) | `python3Packages.aiodiscover: 1.4.2 -> 1.4.4`                              |
| [`e733d8ea`](https://github.com/NixOS/nixpkgs/commit/e733d8ea0aaf0f9fa67a6a89ec3cbcb9d51b0907) | `python3Packages.pydeconz: 83 -> 84`                                       |
| [`8a5b11a4`](https://github.com/NixOS/nixpkgs/commit/8a5b11a4a9708cb1451c1affe303e77c6529d0bc) | `python3Packages.pysyncthru: 0.7.8 -> 0.7.10`                              |
| [`cc8bd845`](https://github.com/NixOS/nixpkgs/commit/cc8bd84575321e5f8815c130fb5b73e8b1ccebde) | `python3Packages.demjson3: init at 3.0.5`                                  |
| [`058e0d67`](https://github.com/NixOS/nixpkgs/commit/058e0d67855cb69fa50b536c5cc4921bc8127e2e) | `python3Packages.zha-quirks: 0.0.61 -> 0.0.62`                             |
| [`608d4c27`](https://github.com/NixOS/nixpkgs/commit/608d4c27ddf6deaba999d479b485afa81b3e1575) | `python3Packages.zigpy: 0.37.1 -> 0.38.0`                                  |
| [`41dbe2e5`](https://github.com/NixOS/nixpkgs/commit/41dbe2e5060e9e894c2a07f2a06fe3a085bcee72) | `python3Packages.zwave-js-server-python: 0.30.0 -> 0.31.1`                 |
| [`b74834c3`](https://github.com/NixOS/nixpkgs/commit/b74834c3a396807ce0a32d622fbbab772f91ad88) | `python3Packages.aiohomekit: 0.6.2 -> 0.6.3`                               |
| [`72175877`](https://github.com/NixOS/nixpkgs/commit/721758774942677e0afa8c10ac2bbbf0bb00380c) | `python3Packages.hass-nabucasa: 0.47.1 -> 0.50.0`                          |
| [`8d249347`](https://github.com/NixOS/nixpkgs/commit/8d249347bb77bb9747f9bce500ae58c8517bfc24) | `python3Packages.hass-nabucasa: 0.46.0 -> 0.47.1`                          |
| [`ca57fe27`](https://github.com/NixOS/nixpkgs/commit/ca57fe27a05517c3cfc55f7cde94803d2f972145) | `python3Packages.distributed: 2021.9.0 -> 2021.9.1`                        |
| [`240e2d76`](https://github.com/NixOS/nixpkgs/commit/240e2d76aadabdf17ed6d1b72c73e3ecbf54e62b) | `python3Packages.dask: 2021.09.0 -> 2021.09.1`                             |
| [`3e805fd2`](https://github.com/NixOS/nixpkgs/commit/3e805fd2800b31e4feb8a4b8128fa498e320ed23) | `python3Packages.s3fs: 2021.8.1 -> 2021.10.0`                              |
| [`229cdc01`](https://github.com/NixOS/nixpkgs/commit/229cdc01f3f962c0732dfe3e73a080752ec11190) | `python3Packages.gcsfs: 2021.08.1 -> 2021.10.0`                            |
| [`bc19c64a`](https://github.com/NixOS/nixpkgs/commit/bc19c64a77965acdaf81bf2ba5add0d3ef293b79) | `python3Packages.fsspec: 2021.08.1 -> 2021.10.0`                           |
| [`93eb7786`](https://github.com/NixOS/nixpkgs/commit/93eb7786c9365981854a98e508d5b1cae5ee2fcf) | `arcanist: Update certs to fix letsencrypt`                                |
| [`1af6417b`](https://github.com/NixOS/nixpkgs/commit/1af6417b8693fc4ce400269cc2594b41db66f1c9) | `nixos/joycond: init`                                                      |
| [`d677a0d3`](https://github.com/NixOS/nixpkgs/commit/d677a0d3257ffe53546fb18bab7dccb96e5c942d) | `joycond: unstable-2021-03-27 -> unstable-2021-07-30`                      |
| [`5c666cdf`](https://github.com/NixOS/nixpkgs/commit/5c666cdf62615442cab413121384588c6ecebef5) | `Re-RAII-ify the NixOS integration test driver's VLAN class.`              |
| [`32face8d`](https://github.com/NixOS/nixpkgs/commit/32face8dea96371239cb4d48b34086940e43c3c6) | `nixos.tests.udisks2: state_dir is now of type pathlib.Path`               |
| [`af859d1d`](https://github.com/NixOS/nixpkgs/commit/af859d1df18517a77440b1e117f670dc7c9f68f6) | `nixos.tests.usbguard: state_dir is now of type pathlib.Path`              |
| [`3f63e3ce`](https://github.com/NixOS/nixpkgs/commit/3f63e3ce653b476554c6c07dc66e9efae73ee9d0) | `nixos/test-driver: fix graphics for VM`                                   |
| [`b2e59bcf`](https://github.com/NixOS/nixpkgs/commit/b2e59bcf778db9be13c675dfc2524962acec2965) | `nixos/build-vms: fix eval`                                                |
| [`b0fc9da8`](https://github.com/NixOS/nixpkgs/commit/b0fc9da879812e47c1ed3438fb0fd51db00a3494) | `nixos/test/test-driver: Class-ify the test driver`                        |
| [`6ef3c96d`](https://github.com/NixOS/nixpkgs/commit/6ef3c96ddf7132e0dbb0d958b03fcc0ce327a0b0) | `doc: reference sourceRoot in description of srcs`                         |
| [`ed5403ef`](https://github.com/NixOS/nixpkgs/commit/ed5403efc317d02de9fbc8c1471e904de0cb0f09) | `nixos.mautrix-facebook: init module`                                      |
| [`cd42b9ff`](https://github.com/NixOS/nixpkgs/commit/cd42b9fff8581b36ddd843241d42e214715af851) | `fetchfirefoxaddon: Allow overriding the src and add a test for it`        |
| [`589c45e3`](https://github.com/NixOS/nixpkgs/commit/589c45e30337d370057700e3e09829347b3b3ecf) | `python3Packages.pytransportnswv2: init at 0.2.4`                          |
| [`5bfa9822`](https://github.com/NixOS/nixpkgs/commit/5bfa982206d60391635a697c797f921fa2207f67) | `python3Packages.gtfs-realtime-bindings: init at 0.0.7`                    |
| [`ac827d46`](https://github.com/NixOS/nixpkgs/commit/ac827d4610552fc7d521b3477377657cd01790e1) | `home-assistant: enable transport_nsw tests`                               |
| [`37fbbcea`](https://github.com/NixOS/nixpkgs/commit/37fbbcea68a83101316c94ff5443133c8d15c9c3) | `home-assistant: update component-packages`                                |
| [`f47aa761`](https://github.com/NixOS/nixpkgs/commit/f47aa7612d35e556348646660a0f0e7b4b20a297) | `python3Packages.pytransportnsw: init at 0.1.1`                            |
| [`7aa540aa`](https://github.com/NixOS/nixpkgs/commit/7aa540aa92ee9793ef97eb4ebaf0d53ac84d87f2) | `wine64: fix eval on Darwin`                                               |
| [`a3735ea9`](https://github.com/NixOS/nixpkgs/commit/a3735ea9d1c4c1c4bc76ae89297d240ad4f8ab02) | `all-packages: expose wine64Packages`                                      |
| [`ededd308`](https://github.com/NixOS/nixpkgs/commit/ededd308a83218db2e69bb3a94df79414c30eb6d) | `nixos/boot: add /var/lib/nixos to pathsNeededForBoot`                     |