### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "107a51dd71aa21234baf20baaeb613d7ff0214ce",
-        "sha256": "070hppxq5dq5zdfrrlqa6xj6naldgs0dakkmyhdvb31axn878hmg",
+        "rev": "0c416075ae75e17db90c4c48d7394a36a8df824c",
+        "sha256": "0xkina9s5pf5bwki17vcsyl6jp6vj0jx65d769znn02c7namvr3p",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/107a51dd71aa21234baf20baaeb613d7ff0214ce.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/0c416075ae75e17db90c4c48d7394a36a8df824c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                 |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`5a0e5409`](https://github.com/NixOS/nixpkgs/commit/5a0e54095aad3643f5e9a7c995b1ccfef848f295) | `pipes-rs: 1.4.4 -> 1.4.5`                                                     |
| [`6c6670d9`](https://github.com/NixOS/nixpkgs/commit/6c6670d9c458e4421e58cc99d6ac55f669a59ac1) | `lima: 0.6.4 -> 0.7.1`                                                         |
| [`882ed22e`](https://github.com/NixOS/nixpkgs/commit/882ed22e5cfcc5863777058799e329896ba607ad) | `cbqn: 0.pre+unstable=2021-10-05 -> 0.pre+unstable=2021-10-09`                 |
| [`9044534a`](https://github.com/NixOS/nixpkgs/commit/9044534a8dd73df87ef35e604d7212f876988b02) | `elan: 1.0.7 -> 1.1.0`                                                         |
| [`981d5317`](https://github.com/NixOS/nixpkgs/commit/981d5317b9722c33a0926929fb589d61c866f6a1) | `gitlint: 0.15.1 -> 0.16.0`                                                    |
| [`34c98d24`](https://github.com/NixOS/nixpkgs/commit/34c98d248ea162a5d7aa8e78a623e20cc3b700cf) | `fetchmail: 6.4.21 -> 6.4.22`                                                  |
| [`99805ce1`](https://github.com/NixOS/nixpkgs/commit/99805ce16739d1eb4d46bd9ccd1218a626b7c9f3) | `nginxModules.upload: init at 2.3.0`                                           |
| [`467e36f5`](https://github.com/NixOS/nixpkgs/commit/467e36f5da2fc8c9cb481d7ce28a8b3725b051b1) | `guitarix: move from Python 2 to Python 3`                                     |
| [`1d90007b`](https://github.com/NixOS/nixpkgs/commit/1d90007b1dd97a6b361c848a92ff2cb317f58865) | `eksctl: 0.68.0 -> 0.69.0`                                                     |
| [`e84f3ad7`](https://github.com/NixOS/nixpkgs/commit/e84f3ad76cf962c1621140528492200a5ed80c1f) | `terrascan: 1.10.0 -> 1.11.0`                                                  |
| [`4715a08d`](https://github.com/NixOS/nixpkgs/commit/4715a08d0872425a73e3a185e9699bc3e4080212) | `python38Packages.mautrix: 0.10.9 -> 0.10.10`                                  |
| [`2a42dff3`](https://github.com/NixOS/nixpkgs/commit/2a42dff30ef818486fe317e66ba748a1424ef552) | `mtm: 1.2.0 -> 1.2.1`                                                          |
| [`a6c34ff3`](https://github.com/NixOS/nixpkgs/commit/a6c34ff3633924f0aa1b91cc0eaa4559986e6633) | `linux: cleanup zlib conditional dependency`                                   |
| [`5f79b7a1`](https://github.com/NixOS/nixpkgs/commit/5f79b7a15b4658caa415e63f3d4e84b4b58f9991) | `mdbook-katex: init @ 0.2.10`                                                  |
| [`f57bed88`](https://github.com/NixOS/nixpkgs/commit/f57bed88326b7b7e3ff6dc97ddeaef5b02f8e510) | `nixos/nextcloud: drop adminpass/dbpass options entirely`                      |
| [`59c0ff2c`](https://github.com/NixOS/nixpkgs/commit/59c0ff2c932d5619f70d776331628abcf0d54180) | `metasploit: 6.1.8 -> 6.1.9`                                                   |
| [`176793b7`](https://github.com/NixOS/nixpkgs/commit/176793b716a1d223753234171f1f8e3656f2da68) | `knockpy: 5.1.0 -> 5.2.0`                                                      |
| [`9f37d6ae`](https://github.com/NixOS/nixpkgs/commit/9f37d6aee028679b8a94be59d74984e708acaa85) | `nixos/nextcloud: put secrets into the environment of nextcloud-setup.service` |
| [`fb405269`](https://github.com/NixOS/nixpkgs/commit/fb405269612ce6df5021e97d57dca9be3bfeed86) | `nixos/nextcloud: minor manual improvements`                                   |
| [`ccbdef3b`](https://github.com/NixOS/nixpkgs/commit/ccbdef3b206c14c588ae6fa2bbd37695a09f998f) | `edk2: 202102 -> 202108`                                                       |
| [`18371000`](https://github.com/NixOS/nixpkgs/commit/183710009626e81af20afeb055b47c866a18c69c) | `tremor-rs: 0.11.5 -> 0.11.6`                                                  |
| [`f64056fc`](https://github.com/NixOS/nixpkgs/commit/f64056fccdc1871a1297d326db6745a3acbefc1e) | `botamusique: unstable-2021-06-01 -> unstable-2021-09-01`                      |