### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0c416075ae75e17db90c4c48d7394a36a8df824c",
-        "sha256": "0xkina9s5pf5bwki17vcsyl6jp6vj0jx65d769znn02c7namvr3p",
+        "rev": "43bbea938785d4228d87e4a443ea82f5ead9bcec",
+        "sha256": "0l81rjpda6nkzzljh0z3g5bz9j3zkhbwp8vhyb6d4nr6q3midhvb",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/0c416075ae75e17db90c4c48d7394a36a8df824c.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/43bbea938785d4228d87e4a443ea82f5ead9bcec.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`43bbea93`](https://github.com/NixOS/nixpkgs/commit/43bbea938785d4228d87e4a443ea82f5ead9bcec) | `lfs: init at 1.0.0 (#141178)`                                                        |
| [`47e66ec1`](https://github.com/NixOS/nixpkgs/commit/47e66ec1d0ef9598d1572cf7a3056aa71db325fa) | `mapcidr: init at 0.0.8 (#141102)`                                                    |
| [`6b9f8629`](https://github.com/NixOS/nixpkgs/commit/6b9f8629d2a612bd8a9425542fe2ed1cb214f775) | `synth: init at 0.5.6`                                                                |
| [`965caf6b`](https://github.com/NixOS/nixpkgs/commit/965caf6b999db180b0d9b11380243d68ab3613ad) | `btcpayserver: 1.2.3 -> 1.2.4`                                                        |
| [`51529190`](https://github.com/NixOS/nixpkgs/commit/515291906eb9fe138f3a52856537157c4f541a1c) | `nbxplorer: 2.2.5 -> 2.2.11`                                                          |
| [`0efe135d`](https://github.com/NixOS/nixpkgs/commit/0efe135d99311b3daa4e081e278d460200cc4105) | `scorecard: 2.2.8 -> 3.0.1`                                                           |
| [`a3660c86`](https://github.com/NixOS/nixpkgs/commit/a3660c86de2803e4d3281947d616ccf404add2ea) | `kubescape: 1.0.88 -> 1.0.109`                                                        |
| [`d002e84b`](https://github.com/NixOS/nixpkgs/commit/d002e84bab94fbdca4a8d2f981225868a24f3a36) | `perlPackages.LaTeXML: backport downgrade to medium security of File::Temp (#141182)` |
| [`454d9f74`](https://github.com/NixOS/nixpkgs/commit/454d9f74104b41adb871f11911dab9e8e960de1a) | `neovide: unstable-2021-08-08 -> unstable-2021-10-09`                                 |
| [`2b06bd2b`](https://github.com/NixOS/nixpkgs/commit/2b06bd2b8aacc25bac08b1a22cc578337db1822d) | `python38Packages.pglast: 3.5 -> 3.6`                                                 |
| [`3ce2e89d`](https://github.com/NixOS/nixpkgs/commit/3ce2e89dec81b09b7b927e469fd401c272ad5aa4) | `mpd: 0.22.10 -> 0.22.11`                                                             |
| [`7938ea67`](https://github.com/NixOS/nixpkgs/commit/7938ea67a717e69d00edab8c2cb6f04c9c469aaf) | `nixos/doc/md-to-db.sh: handle path to nixpkgs with spaces`                           |
| [`ccc287f6`](https://github.com/NixOS/nixpkgs/commit/ccc287f6d9d0039a88eef8d4634856d5f35f2cac) | `terraform-providers.openstack: 1.28.0 -> 1.43.1 (#139753)`                           |
| [`9a8404ee`](https://github.com/NixOS/nixpkgs/commit/9a8404ee692868f23fdce93df34843bf4e758d40) | `python3Packages.teslajsonpy: add new dependency`                                     |
| [`eb0588f4`](https://github.com/NixOS/nixpkgs/commit/eb0588f4b7cbeafbde17475a3b47536025c53978) | `nix-eval-jobs: init at 0.0.1`                                                        |
| [`861c36e3`](https://github.com/NixOS/nixpkgs/commit/861c36e309f8d5d6df0e0e5d9e08ad807d428757) | `python38Packages.teslajsonpy: 0.21.0 -> 1.0.0`                                       |
| [`b7e7d35c`](https://github.com/NixOS/nixpkgs/commit/b7e7d35cccea936bc41d9f2602bda3effee97b0a) | `yarn2nix: workaround for NixOS/nix#5128`                                             |
| [`c2059441`](https://github.com/NixOS/nixpkgs/commit/c205944161d39753a1968aae010060e373a16336) | `lilypond-with-fonts: fix lilypond not finding its libraries`                         |
| [`80d0a6d4`](https://github.com/NixOS/nixpkgs/commit/80d0a6d4438f96750d7ea5a8ae4712854f5858ce) | `python38Packages.deezer-python: 2.4.0 -> 3.1.0`                                      |
| [`d9594771`](https://github.com/NixOS/nixpkgs/commit/d959477134a3e765696bc197ccb678ec97ffd3de) | `python3Packages.labgrid: remove disabled tests`                                      |
| [`f731f82c`](https://github.com/NixOS/nixpkgs/commit/f731f82c975169c259c3a8ee436e0994de4c7237) | `suckit: init at 0.1.2`                                                               |
| [`fbb2cfd0`](https://github.com/NixOS/nixpkgs/commit/fbb2cfd0bb72cd18d523b2b99807c76a3f7d57c4) | `crabz: init at 0.7.2`                                                                |
| [`3ea6c9e4`](https://github.com/NixOS/nixpkgs/commit/3ea6c9e48a40e80fb58fe33c64bc35d41bbd5a13) | `python3Packages.pyswitchbot: 0.11.0 -> 0.12.0`                                       |
| [`864f96cd`](https://github.com/NixOS/nixpkgs/commit/864f96cd7fd732b9339494b2890ebe0685b43a7f) | `libredirect: handle mkdir(2) + mkdirat(2)`                                           |
| [`52c95adb`](https://github.com/NixOS/nixpkgs/commit/52c95adb9315ed032235f8959f8cf8704a8b1583) | `geany: 1.37.1 -> 1.38`                                                               |
| [`2cfc72c4`](https://github.com/NixOS/nixpkgs/commit/2cfc72c44a31a02642fee0d9d9f9ad673168beef) | `apache-airflow: 2.1.2 -> 2.1.4`                                                      |
| [`e531a5a7`](https://github.com/NixOS/nixpkgs/commit/e531a5a7120816144b6e653d6fc186d64f6b9fd9) | `python3Packages.scancode-toolkit: 21.8.4 -> 30.1.0`                                  |
| [`570e2536`](https://github.com/NixOS/nixpkgs/commit/570e2536e8cf525b54f2cc32f61a702c4885edbf) | `python3Packages.license-expression: 1.2 -> 21.6.14`                                  |
| [`54caa413`](https://github.com/NixOS/nixpkgs/commit/54caa4135aa584aead70ce80f169eb5980ddfed9) | `python3Packages.debian-inspector: 21.5.25 -> 30.0.0`                                 |
| [`4521bf49`](https://github.com/NixOS/nixpkgs/commit/4521bf49d19efe245e02ec923296155eb8ae75b9) | `python3Packages.parameter-expansion-patched: init at 0.2.1b4`                        |
| [`6423dc78`](https://github.com/NixOS/nixpkgs/commit/6423dc7828e57abceebcbfdd707b1463a937fc37) | `python3Packages.spdx-tools: 0.6.1 -> 0.7.0a3`                                        |
| [`291d63f8`](https://github.com/NixOS/nixpkgs/commit/291d63f8884b6716525debd7d114aa39f03ad252) | `python3Packages.pygmars: init at 0.7.0`                                              |
| [`16677081`](https://github.com/NixOS/nixpkgs/commit/166770817df5f260b1ace224eafece4209507239) | `python3Packages.extractcode: disable failing test`                                   |
| [`65fe62e0`](https://github.com/NixOS/nixpkgs/commit/65fe62e0205e941d3be226ff5dee3aae00c00c08) | `python3Packages.commoncode: 21.8.31 -> 30.0.0`                                       |
| [`e59dd593`](https://github.com/NixOS/nixpkgs/commit/e59dd593c8ed9271c3f568a9972ed0a697731ca9) | `python3Packages.smbus2: init at 0.4.1`                                               |