### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "43bbea938785d4228d87e4a443ea82f5ead9bcec",
-        "sha256": "0l81rjpda6nkzzljh0z3g5bz9j3zkhbwp8vhyb6d4nr6q3midhvb",
+        "rev": "d5bbb6cd0eebd9de4dde88f3bc1c2d418261dffb",
+        "sha256": "04a3xcpswh527amak6lhpkhcxm7qxlx2pl5sf2md14bxvk4q3v1v",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/43bbea938785d4228d87e4a443ea82f5ead9bcec.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/d5bbb6cd0eebd9de4dde88f3bc1c2d418261dffb.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                     |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`3cc891a4`](https://github.com/NixOS/nixpkgs/commit/3cc891a48b0b01e5f0ec14d7ec5b1edae09b1873) | `kodi: 19.1 -> 19.2`                                               |
| [`9bf9e342`](https://github.com/NixOS/nixpkgs/commit/9bf9e3423be57473c70bf588ffd2711663d7d02c) | `cdk-go: set meta.mainProgram`                                     |
| [`8755e7aa`](https://github.com/NixOS/nixpkgs/commit/8755e7aa4984540ac60c8f361dddeb7163aad7f0) | `gnused,gnused_422: set meta.mainProgram`                          |
| [`96c5dc78`](https://github.com/NixOS/nixpkgs/commit/96c5dc784e6cfdd904877c5b8b337555a11b536d) | `dialogbox: init at 1.0+unstable=2020-11-16`                       |
| [`4c7e1a10`](https://github.com/NixOS/nixpkgs/commit/4c7e1a10b4b6b580c63662423288633990b87f89) | `yarn2nix: fix "rev is not defined" (#141207)`                     |
| [`11ce4818`](https://github.com/NixOS/nixpkgs/commit/11ce48184547625a2a02a0902839481336c6134d) | `nixos/tests/prowlarr: init`                                       |
| [`3d79c925`](https://github.com/NixOS/nixpkgs/commit/3d79c9250aadebe59dcdf43352d9128ddbff675c) | `nixos/prowlarr: init`                                             |
| [`4228bbe0`](https://github.com/NixOS/nixpkgs/commit/4228bbe0b2a7318878a3cd49e808866472413262) | `prowlarr: init at 0.1.1.978`                                      |
| [`fb79f910`](https://github.com/NixOS/nixpkgs/commit/fb79f910b79c70a4bbbf7a19873f8a95b6732df2) | `mininet: 2.3.0d6 -> 2.3.0`                                        |
| [`acb7f9b0`](https://github.com/NixOS/nixpkgs/commit/acb7f9b0ce4f19cbc2104fc560b6503ae24867af) | `hackrf: 2018.01.1 -> 2021.03.1`                                   |
| [`34f77f42`](https://github.com/NixOS/nixpkgs/commit/34f77f423c0d86a5b0928f1fc5f7550374fffedf) | `jackett: 0.18.582 -> 0.18.925`                                    |
| [`58269d48`](https://github.com/NixOS/nixpkgs/commit/58269d4875b357fba7a34608bbe5691eecf30fb4) | `yt-dlp: 2021.9.25 -> 2021.10.10`                                  |
| [`f52699bc`](https://github.com/NixOS/nixpkgs/commit/f52699bc713545e32b5aaa1290e03c4ebf0d4110) | `python3Packages.pytest-rerunfailures: 10.1 → 10.2 (#141166)`      |
| [`4172adde`](https://github.com/NixOS/nixpkgs/commit/4172adde122752268ce9c415723a5f41edb26e68) | `clickhouse: fix non-x86 build (#141009)`                          |
| [`e3126455`](https://github.com/NixOS/nixpkgs/commit/e312645535f1edab0e5ed7356fba009a8a4b7359) | `cloudfoundry-cli: 7.3.0 -> 8.0.0`                                 |
| [`1c9afc5a`](https://github.com/NixOS/nixpkgs/commit/1c9afc5a883065552190b7bae6ae04b6abfe0312) | `releaseTools.debBuild: fix invocation`                            |
| [`9aae7137`](https://github.com/NixOS/nixpkgs/commit/9aae71379d4e07a7ab4be4c8cfcae5e63252fe95) | `nixos/wakeonlan: add note to rename.nix`                          |
| [`7d9d6c82`](https://github.com/NixOS/nixpkgs/commit/7d9d6c825f990ef389dd538513a73677ec84ab56) | `python38Packages.tasklib: 2.4.0 -> 2.4.3`                         |
| [`0e1dba38`](https://github.com/NixOS/nixpkgs/commit/0e1dba3824894c308d6200be0e121a71944bf2ab) | `maintainers: add jdreaver`                                        |
| [`11e5bc64`](https://github.com/NixOS/nixpkgs/commit/11e5bc6438b7bdbbf2caf889dc7bd20cbd29185d) | `marwaita: 10.3 -> 11.1`                                           |
| [`c21d56e6`](https://github.com/NixOS/nixpkgs/commit/c21d56e6dbf23d1ac755fe7d88ab97f25ccb1c23) | `python38Packages.pikepdf: 3.1.1 -> 3.2.0`                         |
| [`acc4cf0d`](https://github.com/NixOS/nixpkgs/commit/acc4cf0d34595e07c488ae8b817b6255b5cb74df) | `python38Packages.pg8000: 1.21.2 -> 1.21.3`                        |
| [`dabafc8a`](https://github.com/NixOS/nixpkgs/commit/dabafc8ac748ce035d8e8c9e9072fb57f8a51235) | `mopidy-youtube: enable tests`                                     |
| [`fc6631d3`](https://github.com/NixOS/nixpkgs/commit/fc6631d3e728df4b6f321d53aa258bbd48c31325) | `xorg.xev: 1.2.3 -> 1.2.4`                                         |
| [`69fec99e`](https://github.com/NixOS/nixpkgs/commit/69fec99e6702dc90262deaeaed326d4e03e6f8d6) | `python38Packages.pytelegrambotapi: 4.1.0 -> 4.1.1`                |
| [`397a555b`](https://github.com/NixOS/nixpkgs/commit/397a555b699bb1ce0488bc8f2bdbfc30db3ebc86) | `python38Packages.nunavut: 1.4.2 -> 1.5.0`                         |
| [`9ab6478c`](https://github.com/NixOS/nixpkgs/commit/9ab6478cae969f486ea9a83b6bf24c8d351be40c) | `python38Packages.django-dynamic-preferences: 1.10.1 -> 1.11.0`    |
| [`e7a771e4`](https://github.com/NixOS/nixpkgs/commit/e7a771e4cf25fa3a34e5f721cb0b2b8cae9e9c43) | `cloudflared: 2021.9.1 -> 2021.9.2`                                |
| [`0b2b0331`](https://github.com/NixOS/nixpkgs/commit/0b2b0331f0de0fba15d3eb813032250e634bfedb) | `coreboot-toolchain: Use sources.nix generated by update.sh`       |
| [`5608c26f`](https://github.com/NixOS/nixpkgs/commit/5608c26f72125b4b14d8a74e37fd34afaf3b616c) | `python3Packages.furo: 2021.9.22 -> 2021.10.9`                     |
| [`12623a3e`](https://github.com/NixOS/nixpkgs/commit/12623a3e2933491a25c867943456e3f53d3702c4) | `python3Packages.spyse-python: init at 2.2.3`                      |
| [`bc482d83`](https://github.com/NixOS/nixpkgs/commit/bc482d83e6e5ead1922081c5eba4124c6e533532) | `python3Packages.limiter: init at 0.1.2`                           |
| [`60b4a5ea`](https://github.com/NixOS/nixpkgs/commit/60b4a5ea82b2551717bcc16a10245fea25980a7b) | `vscode-extensions.vadimcn.vscode-lldb: 1.6.7 -> 1.6.8`            |
| [`35a26a5b`](https://github.com/NixOS/nixpkgs/commit/35a26a5b210eb0ac5656f21adee96281339a1b36) | `chromiumDev: 96.0.4655.0 -> 96.0.4662.6`                          |
| [`28383a92`](https://github.com/NixOS/nixpkgs/commit/28383a922e5660ce184fbfdd6b50913360d32182) | `coreboot-toolchain: Introduce script for generating sources file` |
| [`4dc0be75`](https://github.com/NixOS/nixpkgs/commit/4dc0be7557d54872961a33334659e1fccdb70f53) | `python3Packages.greeclimate: 0.11.8 -> 0.11.9`                    |
| [`8a6c987c`](https://github.com/NixOS/nixpkgs/commit/8a6c987c2bb9b532eba3d9ee930f2b56c4763371) | `python3Packages.youless-api: 0.13 -> 0.14`                        |
| [`1ab3b970`](https://github.com/NixOS/nixpkgs/commit/1ab3b9704ed71906abbce1de03c9a9caad8b4dd3) | `depotdownloader: 2.4.1 -> 2.4.5`                                  |
| [`b62cda1a`](https://github.com/NixOS/nixpkgs/commit/b62cda1af2659128ee8162154e879a7dc67d0127) | `phpPackages.composer: 2.1.8 -> 2.1.9`                             |
| [`cff7863c`](https://github.com/NixOS/nixpkgs/commit/cff7863c34b759810a73b6db0e91b032b338ccf8) | `coreboot-toolchain: Use git repository as source`                 |
| [`d66a5122`](https://github.com/NixOS/nixpkgs/commit/d66a5122227d4610efe7846babcc58a4b20064b9) | `libjaylink: Init at 0.2.0`                                        |
| [`07f71d21`](https://github.com/NixOS/nixpkgs/commit/07f71d21995f0707758370bbaf850bfa509321a5) | `python38Packages.pymavlink: 2.4.16 -> 2.4.17`                     |
| [`82c0181d`](https://github.com/NixOS/nixpkgs/commit/82c0181dfb3dc951156097752d5a876754db3591) | `python38Packages.mypy-boto3-s3: 1.18.57 -> 1.18.58`               |
| [`d43c27b9`](https://github.com/NixOS/nixpkgs/commit/d43c27b96be926d4b7d96dae62661f9c3b59271e) | `python3Packages.guppy3: 3.1.1 -> 3.1.2`                           |
| [`a720b733`](https://github.com/NixOS/nixpkgs/commit/a720b7331f0febb6721c9ea641f59c290a4e2394) | `python38Packages.flask-jwt-extended: 4.3.0 -> 4.3.1`              |
| [`38392881`](https://github.com/NixOS/nixpkgs/commit/383928815fd9fc828b7bb43c1f3edeeb50ab08e4) | `ungoogled-chromium: 94.0.4606.71 -> 94.0.4606.81`                 |
| [`8f93180a`](https://github.com/NixOS/nixpkgs/commit/8f93180aa40af1c3ba8314e53fbb925e8387d12f) | `hdl-dump: 20202808 -> unstable-2021-08-20, change upstream`       |
| [`57a1b847`](https://github.com/NixOS/nixpkgs/commit/57a1b8476b0d9803e5066dfbb68d6b3cee28e8c2) | `opendht: support proxy`                                           |
| [`12168640`](https://github.com/NixOS/nixpkgs/commit/121686406db45c0901ab693ea1ce65f35572dafa) | `python38Packages.icalendar: 4.0.7 -> 4.0.8`                       |
| [`a1128e9f`](https://github.com/NixOS/nixpkgs/commit/a1128e9f25cceb308de82773fe85f9c03c26548c) | `cdk-go: init at 1.0.4`                                            |
| [`78eb37ec`](https://github.com/NixOS/nixpkgs/commit/78eb37eccc7ecad74ccad39495675bf7bfb20410) | `pypi-mirror: 4.0.6 -> 4.0.7`                                      |
| [`468514fd`](https://github.com/NixOS/nixpkgs/commit/468514fdaa134ba2ba64ad5a28ea0ebce3d6aeba) | `bluejeans-gui: 2.23.0.39 -> 2.24.0.89`                            |
| [`7ce7805e`](https://github.com/NixOS/nixpkgs/commit/7ce7805e9eaa71e868641d429d7f86f5efb9de81) | `apacheKafka: 2.8.0 -> 2.8.1`                                      |
| [`70ec6095`](https://github.com/NixOS/nixpkgs/commit/70ec60957d8c90ba10631a4498b3ba6b7eb62302) | `python38Packages.bids-validator: 1.8.3 -> 1.8.4`                  |
| [`8d109b4f`](https://github.com/NixOS/nixpkgs/commit/8d109b4f1c7ff1fbbfd187e190e87f7d8edbd79f) | `sysvinit: 2.99 -> 3.00`                                           |
| [`6302568b`](https://github.com/NixOS/nixpkgs/commit/6302568bcb501a0dfe6e2f9d9e019c2eeb197b95) | `python38Packages.jaraco_itertools: 6.0.1 -> 6.0.3`                |
| [`0568ec01`](https://github.com/NixOS/nixpkgs/commit/0568ec0129bfedf8c54df705ee1f205f8715ecb2) | `python38Packages.pyfuse3: 3.2.0 -> 3.2.1`                         |
| [`477064c0`](https://github.com/NixOS/nixpkgs/commit/477064c0cd0f13c21e91cfbe2f72d852dcaf2892) | `dogecoin: 1.14.3 -> 1.14.4`                                       |
| [`7445068e`](https://github.com/NixOS/nixpkgs/commit/7445068e4490f7bf30471f4d5211df6e8687c00f) | `tboot: 1.10.1 -> 1.10.2`                                          |
| [`ba1dce6a`](https://github.com/NixOS/nixpkgs/commit/ba1dce6af58083b24d0e8b0d7d262f8c9c9a33ac) | `spdk: 21.04 -> 21.07`                                             |
| [`660427a0`](https://github.com/NixOS/nixpkgs/commit/660427a0372cf515a62614e1b11a5ae81d8bcaaf) | `sickgear: 0.23.16 -> 0.24.15`                                     |
| [`34e5ebf6`](https://github.com/NixOS/nixpkgs/commit/34e5ebf62d07435482186c827939073ccd3ac57f) | `shairport-sync: 3.3.7 -> 3.3.8`                                   |