### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d5bbb6cd0eebd9de4dde88f3bc1c2d418261dffb",
-        "sha256": "04a3xcpswh527amak6lhpkhcxm7qxlx2pl5sf2md14bxvk4q3v1v",
+        "rev": "e4ef597edfd8a0ba5f12362932fc9b1dd01a0aef",
+        "sha256": "1w6y7ma2crcsfph60z8j1k3af0v2m110cbjrb62z287mn4skhqjs",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/d5bbb6cd0eebd9de4dde88f3bc1c2d418261dffb.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/e4ef597edfd8a0ba5f12362932fc9b1dd01a0aef.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                   |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
| [`c84b55bb`](https://github.com/NixOS/nixpkgs/commit/c84b55bbe6866e714ed3bb6de77e0acefb8e2eff) | `nixos/git: add lfs option to allow enabling and installing lfs easily`                          |
| [`5ec9a816`](https://github.com/NixOS/nixpkgs/commit/5ec9a816d28033c592447f70e8c79f3658dfd712) | `tinycc: 0.9.27 -> unstable-2021-07-27`                                                          |
| [`316effbc`](https://github.com/NixOS/nixpkgs/commit/316effbc595ef657bcc1f81d4550bccd022ebbea) | `ocaml-ng.ocamlPackages_4_13.ocaml: 4.13.0 → 4.13.1`                                             |
| [`fbabf7e5`](https://github.com/NixOS/nixpkgs/commit/fbabf7e511ae38b633ad637e7d718a1f130f6230) | `vimPlugins: update`                                                                             |
| [`aa063c34`](https://github.com/NixOS/nixpkgs/commit/aa063c34b0135422fe2f483481504931540b5818) | `vimPlugins.lsp-vimway-diag-nvim: rename to diaglist-nvim`                                       |
| [`3ae4c035`](https://github.com/NixOS/nixpkgs/commit/3ae4c035be8d509d3264d5940754013064abb9e5) | `coreboot-toolchain: minor cleanup`                                                              |
| [`63cdb3f7`](https://github.com/NixOS/nixpkgs/commit/63cdb3f7a2252f8361ff16ae75c24179188a5499) | `ec2-metadata-mock: init at 1.9.2 (#140589)`                                                     |
| [`2e8e1cbd`](https://github.com/NixOS/nixpkgs/commit/2e8e1cbdb89603ea2e49a074bfb340c37ab0ba34) | `sumneko-lua-language-server: 2.4.1 -> 2.4.2`                                                    |
| [`5eeeb41a`](https://github.com/NixOS/nixpkgs/commit/5eeeb41ae9caec8fe083accce62e429ff5dc8bbe) | `mongoaudit: init at 0.1.1`                                                                      |
| [`e2b2b59a`](https://github.com/NixOS/nixpkgs/commit/e2b2b59a4d9021937b70b6fab6d64c1d1e335327) | `cameradar: init at 5.0.1`                                                                       |
| [`4a49c7bf`](https://github.com/NixOS/nixpkgs/commit/4a49c7bf1f11b03db529410d614a8cd0fb974f11) | `octave: 6.2.0 -> 6.3.0`                                                                         |
| [`dc5810ad`](https://github.com/NixOS/nixpkgs/commit/dc5810ada6eebd048c091e6ba1bd36d628748db1) | `strongswan: fix build against -fno-common toolchain`                                            |
| [`ca80035f`](https://github.com/NixOS/nixpkgs/commit/ca80035fb8398f4baf8ff4c45544d2645cf63ace) | `bearssl: fix cross`                                                                             |
| [`d23b22e4`](https://github.com/NixOS/nixpkgs/commit/d23b22e4f98f0ae0c218b552cb9878e9144ce38b) | `dejagnu: 1.6.2 -> 1.6.3 (#141206)`                                                              |
| [`1657cc5d`](https://github.com/NixOS/nixpkgs/commit/1657cc5dc5c006ddbf8e8cabd14c457651cd4806) | `python3Packages.homepluscontrol: 0.0.61 -> 0.1`                                                 |
| [`decdfee1`](https://github.com/NixOS/nixpkgs/commit/decdfee17ab4ffa4ac70c36d4cbccf00bdc12a34) | `grafana-image-renderer: 3.2.0 -> 3.2.1`                                                         |
| [`641596e4`](https://github.com/NixOS/nixpkgs/commit/641596e4890619e2419ab30013be8ccb9432cc08) | `python3Packages.pyhaversion: 21.07.0 -> 21.10.1`                                                |
| [`4ac94527`](https://github.com/NixOS/nixpkgs/commit/4ac94527e4bd94e6f96a6b046309699a34bf3ff2) | `wine{Unstable,Staging}: 6.18 -> 6.19`                                                           |
| [`5d0a6578`](https://github.com/NixOS/nixpkgs/commit/5d0a65783418b1ccb294697916d1edc9a7322cce) | `wine{Unstable,Staging}: 6.17 -> 6.18`                                                           |
| [`637be68d`](https://github.com/NixOS/nixpkgs/commit/637be68d8fb04942585fe3c02fb16d5c46b76baa) | `phpExtensions.amqp: init at 1.11.0beta`                                                         |
| [`813fb1e6`](https://github.com/NixOS/nixpkgs/commit/813fb1e6ac21a8ffb59a61742d92b4d002cf15fc) | `i-dot-ming: init 7.01`                                                                          |
| [`2796850d`](https://github.com/NixOS/nixpkgs/commit/2796850d20aebaa1a0c907cc3be2be62501c15d7) | `maintainers: add linsui`                                                                        |
| [`75ec332e`](https://github.com/NixOS/nixpkgs/commit/75ec332e6a0cdaae0014701ce92d402801854014) | `kippo: cleanup the corresponding broken module.`                                                |
| [`d2ef345f`](https://github.com/NixOS/nixpkgs/commit/d2ef345f75b77eee17d4efc7722226a8f58f2823) | `Replaced libspatialite -> libspatialite.dev in configureFlags so that it gets actually enabled` |
| [`3fbb3a13`](https://github.com/NixOS/nixpkgs/commit/3fbb3a13c8db51024be0768cd18090ca36bda136) | `python39Packages.phik: fix build`                                                               |
| [`98a1dcf5`](https://github.com/NixOS/nixpkgs/commit/98a1dcf535ecba48ead2ff149b70c4bd1bed5509) | `wxsqlite3: 4.6.4 -> 4.7.3`                                                                      |
| [`2ed04ad7`](https://github.com/NixOS/nixpkgs/commit/2ed04ad778a3c034d759c7a3e6043062425c03b6) | `gnomeExtensions.emoji-selector: 19 -> 20`                                                       |