### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2ae14350dd34a0795ec418a03c076ad6205c0962",
-        "sha256": "0p8vc1p45xw063a22wl4jqikmsjbyga8a8zf1npyswday95156ax",
+        "rev": "bc12543f329c4db811213652fd95f88fa3c7e8f2",
+        "sha256": "0j2plagmh9i1sc2b3p00vq21c5ks2mg5f68c1zs51k5wbm8ig2qn",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/2ae14350dd34a0795ec418a03c076ad6205c0962.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/bc12543f329c4db811213652fd95f88fa3c7e8f2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                 |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`0878b469`](https://github.com/NixOS/nixpkgs/commit/0878b4691772e3045de6f58f42143bd9f61b7330) | `nixos/release notes: correction`                                              |
| [`475a6dd9`](https://github.com/NixOS/nixpkgs/commit/475a6dd9b775b6d9fcf3cfbc1463316945664fd4) | `nixos/changelog: rephrasing plasma update`                                    |
| [`8d2d6414`](https://github.com/NixOS/nixpkgs/commit/8d2d64142b98ab27a914243b1af463a2d49b7792) | `nixos/doc: Plasma wayland changelog`                                          |
| [`763a0014`](https://github.com/NixOS/nixpkgs/commit/763a0014c8f1d69f0b1675e4fc082399f425941a) | `nixos/plasma: remove dead code`                                               |
| [`4832352d`](https://github.com/NixOS/nixpkgs/commit/4832352d023fdd9546748f33c499034d722382ba) | `nixos/plasma: use upstream xsession/wayland files`                            |
| [`40317fe7`](https://github.com/NixOS/nixpkgs/commit/40317fe7a5f15212c48fb51ae638f99d45a39e8c) | `sickgear: 0.24.15 → 0.25.11`                                                  |
| [`9d02ea53`](https://github.com/NixOS/nixpkgs/commit/9d02ea53de3ad67e47456162cc906db2bbbb2b70) | `cadical: include C++ headers`                                                 |
| [`e9cd6926`](https://github.com/NixOS/nixpkgs/commit/e9cd692673f1d321e6c6817e453912c9b37cf765) | `terraform_1_0: 1.0.8 -> 1.0.9`                                                |
| [`ca75c341`](https://github.com/NixOS/nixpkgs/commit/ca75c341905e865185951ef33ff982929a5a0370) | `dico: python2 → python3`                                                      |
| [`28a6e2c1`](https://github.com/NixOS/nixpkgs/commit/28a6e2c1766ccb77346fba2dadb7b4c1d213d58b) | `vscode: 1.61.0 -> 1.61.1`                                                     |
| [`e1951b3f`](https://github.com/NixOS/nixpkgs/commit/e1951b3fb2cf1af71049b448960d61eb3305fbff) | `gh: 2.0.0 -> 2.1.0`                                                           |
| [`12a2ef34`](https://github.com/NixOS/nixpkgs/commit/12a2ef34b5097dd89ee2966effd970ecbbdd7f8b) | `mint: crystal_1_0 → crystal`                                                  |
| [`a0b8a902`](https://github.com/NixOS/nixpkgs/commit/a0b8a902ff240c666f1fe103ba3e38cbce76872a) | `psi-plus: 1.5.1549 -> 1.5.1556-2`                                             |
| [`4e2085f3`](https://github.com/NixOS/nixpkgs/commit/4e2085f338e183ca0e24a3d13308bf9ffaf15532) | `shards: 0.15 → 0.16`                                                          |
| [`b367ab9a`](https://github.com/NixOS/nixpkgs/commit/b367ab9ad195ae4ffc6bc2ea39d30e36a59c3939) | `thicket: crystal_1_0 → crystal`                                               |
| [`70dda296`](https://github.com/NixOS/nixpkgs/commit/70dda29693d18d40af668fd706bca1fd873050bc) | `verco: 6.6.0 -> 6.7.0`                                                        |
| [`4f5c4544`](https://github.com/NixOS/nixpkgs/commit/4f5c454408a14f4f1f8c737f85c6b18f252d6393) | `python3Packages.adafruit-platformdetect: 3.15.3 -> 3.16.0`                    |
| [`875bb31d`](https://github.com/NixOS/nixpkgs/commit/875bb31d269f22f1a6df46d3bd23d4707eed41af) | `linode-cli: update script fix #3`                                             |
| [`235dccbf`](https://github.com/NixOS/nixpkgs/commit/235dccbfff4fd3aa5462138d2d557ed4ab7dc6bc) | `k3s: update script fix #3`                                                    |
| [`0b32a425`](https://github.com/NixOS/nixpkgs/commit/0b32a42531e7f3609abe431274e2b4669c0c0b07) | `linkerd: update script fix #3`                                                |
| [`f8d89878`](https://github.com/NixOS/nixpkgs/commit/f8d898781a7af5378eec09f0ff268badd209f5c1) | `fluxcd: update script fix #3`                                                 |
| [`dd5f07af`](https://github.com/NixOS/nixpkgs/commit/dd5f07afca27571e567cd902c2e64409e4a485be) | `linux: build dtbs in parallel (#106846)`                                      |
| [`30aeeade`](https://github.com/NixOS/nixpkgs/commit/30aeeaded47d4e246941147acaa357d1605ad486) | `yarn2nix: fix running without --no-patch`                                     |
| [`78f1b430`](https://github.com/NixOS/nixpkgs/commit/78f1b43053ff9866db5d9acf33ee9a93e7246a21) | `crystal: drop 0.36.1`                                                         |
| [`e36b70ed`](https://github.com/NixOS/nixpkgs/commit/e36b70ed550e3ed85386e30dd5006fea46080fc8) | `swec: remove`                                                                 |
| [`e694aebd`](https://github.com/NixOS/nixpkgs/commit/e694aebd1057d0ae65d9e45251b660c480849433) | `in-formant: init at 2021-06-30`                                               |
| [`53ae18e4`](https://github.com/NixOS/nixpkgs/commit/53ae18e4e11ffbed2e4f9c77c6d86a3d2d1c7586) | `fclones: 0.16.0 -> 0.16.1`                                                    |
| [`56c049ae`](https://github.com/NixOS/nixpkgs/commit/56c049aea1bdde75024cb517ca4dfbc587267041) | `python38Packages.phonenumbers: 8.12.34 -> 8.12.35`                            |
| [`48d57557`](https://github.com/NixOS/nixpkgs/commit/48d57557ea2523c9ab355a7d2199b01a5c7646ee) | `minetime: removal`                                                            |
| [`bbf95adc`](https://github.com/NixOS/nixpkgs/commit/bbf95adcbe7b3d5266bff5ace4723e72575d24bb) | `Grammar fixup`                                                                |
| [`4c36e06e`](https://github.com/NixOS/nixpkgs/commit/4c36e06ebe839bf2ca1caaa4dcd45cfee6b0dd78) | `python38Packages.pex: 2.1.51 -> 2.1.52`                                       |
| [`9c54b572`](https://github.com/NixOS/nixpkgs/commit/9c54b572b350d1ff22024ffeb3e8f8439367da5f) | `python38Packages.pg8000: 1.21.3 -> 1.22.0`                                    |
| [`a98e81a9`](https://github.com/NixOS/nixpkgs/commit/a98e81a942ffc22a18bd137c9403e6940c247822) | `electron-cash: 4.2.4 -> 4.2.5`                                                |
| [`69b75998`](https://github.com/NixOS/nixpkgs/commit/69b75998a198a601f1f1e80aadbffe5eb789307a) | `_1password-gui: 8.2.0 -> 8.3.0`                                               |
| [`42670f62`](https://github.com/NixOS/nixpkgs/commit/42670f62f21298cb3fc2ce06e10eb402fb1d3638) | `session-desktop-appimage: 1.7.1 -> 1.7.3`                                     |
| [`e7331d2e`](https://github.com/NixOS/nixpkgs/commit/e7331d2e855145c651f9c2370e6732e5e443a27b) | `gitlab: 14.3.2 -> 14.3.3`                                                     |
| [`979ad94f`](https://github.com/NixOS/nixpkgs/commit/979ad94fe874a3c42f8d698c3861579bbfe12b26) | `csound: use fluidsynth instead of fluidsynth_1`                               |
| [`30022626`](https://github.com/NixOS/nixpkgs/commit/300226261fe5bcabb070a68c1a837e6938566370) | `nixos/unifi: fix unifi ExecStop= being incompatible with systemd`             |
| [`72fbd63c`](https://github.com/NixOS/nixpkgs/commit/72fbd63c5c14e29b36e3161b086a653dd9a87158) | `nixos/prometheus: fix node exporter timex collector`                          |
| [`ae7ce180`](https://github.com/NixOS/nixpkgs/commit/ae7ce180dd8bd30721d19dd1c2e6af00fce0d9ec) | `nixos/prometheus: fix node exporter systemd collector`                        |
| [`476635af`](https://github.com/NixOS/nixpkgs/commit/476635afe170dcfe49f3de533c4b05bb6fb094a8) | `Drop myself from meta.maintainers for most packages.`                         |
| [`51f32e34`](https://github.com/NixOS/nixpkgs/commit/51f32e34abeaaafe72d4afcc4b23b0544a4bf828) | `linuxKernel.kernels.linux_xanmod: 5.14.9 -> 5.14.12`                          |
| [`cafe9f88`](https://github.com/NixOS/nixpkgs/commit/cafe9f88fc388a18e5437ffe01c359ab9467f21f) | `leo2: 1.6.2 → 1.7.0`                                                          |
| [`81e6a653`](https://github.com/NixOS/nixpkgs/commit/81e6a653a37423162f3f65b6f46211823dd4772c) | `deepdiff: 5.5.0 -> 5.6.0`                                                     |
| [`f0374ee2`](https://github.com/NixOS/nixpkgs/commit/f0374ee2f58bd8772269db75314ad643a47f9e52) | `vimPlugins: update`                                                           |
| [`b91ec507`](https://github.com/NixOS/nixpkgs/commit/b91ec507be2a79ffddbb9c08ee06a718ab05ecfc) | `packetdrill: pull upstream fix for fno-common toolchains (#141574)`           |
| [`b7451b5d`](https://github.com/NixOS/nixpkgs/commit/b7451b5d6eca97ae48f55c10702931a0aa035393) | `shotwell: 0.31.3 -> 0.30.14`                                                  |
| [`958bc223`](https://github.com/NixOS/nixpkgs/commit/958bc2235c02c76c7ccf0a3a7839f4eca50aae29) | `sumneko-lua-language-server: 2.4.2 -> 2.4.3`                                  |
| [`23dcb158`](https://github.com/NixOS/nixpkgs/commit/23dcb15889a1edf2790d7bc472109a3368aee29f) | `python38Packages.google-cloud-container: 2.9.0 -> 2.10.0`                     |
| [`e0c989f4`](https://github.com/NixOS/nixpkgs/commit/e0c989f46b6c1c3a9f327af037f28b1366fd9b6b) | `tree-sitter: add alemuller/tree-sitter-make`                                  |
| [`b752cde8`](https://github.com/NixOS/nixpkgs/commit/b752cde8a96fe50411968f3679edb8eac5e959e7) | `librespot: 0.2.0 -> 0.3.0`                                                    |
| [`bc17a539`](https://github.com/NixOS/nixpkgs/commit/bc17a53990e9b98ba31b1dd1fbd36426674ce962) | `python3Packages.timecop: init at 0.5.0dev`                                    |
| [`5c22f8b2`](https://github.com/NixOS/nixpkgs/commit/5c22f8b2667b209b542462f4b2c9acb5ff052194) | `python38Packages.emoji: 1.6.0 -> 1.6.1`                                       |
| [`2cc2677a`](https://github.com/NixOS/nixpkgs/commit/2cc2677a6d88e0e72d07eaae79a4869c551236c8) | `oh-my-zsh: 2021-10-11 -> 2021-10-13`                                          |
| [`db3aa421`](https://github.com/NixOS/nixpkgs/commit/db3aa421df73f43c03ad266619e22ce7c5354d92) | `libshumate: print test logs on failure`                                       |
| [`3cc0c3ab`](https://github.com/NixOS/nixpkgs/commit/3cc0c3ab3f461c89acc2dad890711ad8c151e1dc) | `easyeffects: 6.0.3 → 6.1.3`                                                   |
| [`3e881e56`](https://github.com/NixOS/nixpkgs/commit/3e881e5692cff270f16c0cc4a89d12d0dcbc38c5) | `easyeffects: fix maximizer`                                                   |
| [`c57f0ff4`](https://github.com/NixOS/nixpkgs/commit/c57f0ff44e8ccf51a8dee159c8332ed695f197ea) | `easyeffects: add dependencies forgotten in 6.0.3 bump`                        |
| [`cead1141`](https://github.com/NixOS/nixpkgs/commit/cead114134280e790a0b9f9d9ed7cd97680b85f0) | `easyeffects: drop accidental GTK3 dependency`                                 |
| [`01478aef`](https://github.com/NixOS/nixpkgs/commit/01478aefb3935b463849bc5e64af367a468538a7) | `drawing: 0.8.0 -> 0.8.3`                                                      |
| [`e90c3e2f`](https://github.com/NixOS/nixpkgs/commit/e90c3e2fe5039095f1c1f62587f131fc25ef8485) | `onboard: move python dependencies to pythonPath`                              |
| [`6fbc9770`](https://github.com/NixOS/nixpkgs/commit/6fbc97704c01da5aa999983acdec7639fd9d7f9b) | `onboard: fix indicator support`                                               |
| [`49430336`](https://github.com/NixOS/nixpkgs/commit/49430336270fe0c5487165152632ac226092187e) | `python38Packages.versioneer: 0.20 -> 0.21`                                    |
| [`540dc908`](https://github.com/NixOS/nixpkgs/commit/540dc908cacb551be8ced7291dc8ca75a57b2f96) | `nixos/test-runner: Print exceptions that happen`                              |
| [`07289dc5`](https://github.com/NixOS/nixpkgs/commit/07289dc5ce973505cec8918741a9fbb12629c540) | `python3Packages.pyvicare: 2.9.1 -> 2.13.0`                                    |
| [`ce7c0c25`](https://github.com/NixOS/nixpkgs/commit/ce7c0c25dd1519e0fec1ff1a17e34759e0d02eea) | `linuxPackages.tbs: mark broken`                                               |
| [`78d51d31`](https://github.com/NixOS/nixpkgs/commit/78d51d318ccc4eaab202f71d7585e4e6626b48d5) | `verco: 6.5.5 -> 6.6.0`                                                        |
| [`75d7a40d`](https://github.com/NixOS/nixpkgs/commit/75d7a40d2e3d03582e329bc11627b6ba271fed35) | `crystal: 1.1.1 → 1.2.0`                                                       |
| [`8a9d300a`](https://github.com/NixOS/nixpkgs/commit/8a9d300a102f65e42c22a55d22650c1ce9cde6ac) | `crystal: 1.0.0 → 1.1.1`                                                       |
| [`800ceaf1`](https://github.com/NixOS/nixpkgs/commit/800ceaf1bdba85525015c967eb9921977a35090a) | `gst_all_1.gst-plugins-good: disable asserts`                                  |
| [`0c372b79`](https://github.com/NixOS/nixpkgs/commit/0c372b790e9d762697388e57097e8ee581085b14) | `dfu-util: 0.10 -> 0.11`                                                       |
| [`7db1198c`](https://github.com/NixOS/nixpkgs/commit/7db1198c8e3fcf761411c816e1101af83d072c24) | `ctx: init at 0.pre+date=2021-10-09`                                           |
| [`1a8fc0bb`](https://github.com/NixOS/nixpkgs/commit/1a8fc0bb5245d190dad9823d6c19badc1b3bbfa1) | `gst_all_1.gst-plugins-bad: disable asserts`                                   |
| [`4245631e`](https://github.com/NixOS/nixpkgs/commit/4245631ef84d2670a71beea7d7af02abb66d7000) | `python38Packages.teslajsonpy: 1.0.0 -> 1.0.1`                                 |
| [`c9b7cc79`](https://github.com/NixOS/nixpkgs/commit/c9b7cc79e6ce6b38debb28ab0d06051a4fb5b336) | `lib.warn: Add NIX_ABORT_ON_WARN for call traces`                              |
| [`f99f734f`](https://github.com/NixOS/nixpkgs/commit/f99f734f2b081344cff7bd6beed0e45b051854c9) | `hexchat: 2.14.3 -> 2.16.0`                                                    |
| [`8827abe7`](https://github.com/NixOS/nixpkgs/commit/8827abe7d0ba00d2ecab1e273f8704d1a5bc33f4) | `hydrus: 457 -> 458`                                                           |
| [`c4b786be`](https://github.com/NixOS/nixpkgs/commit/c4b786be2d8d19cc59a9b676f4c62bd9ae5e733e) | `python38Packages.sunpy: 3.0.1 -> 3.0.2`                                       |
| [`bb471d59`](https://github.com/NixOS/nixpkgs/commit/bb471d59bcbc93f904f44859b4dd0a547d85058a) | `python3Packages.velbus-aio: 2021.9.4 -> 2021.10.1`                            |
| [`2dd79cb6`](https://github.com/NixOS/nixpkgs/commit/2dd79cb6596008c2080f3a9a8120221ff743521e) | `intel-media-driver: 21.3.4 -> 21.3.5`                                         |
| [`686a5b08`](https://github.com/NixOS/nixpkgs/commit/686a5b087a7c7959034d6a2d5e608dff1797b61a) | `anytype: 0.20.2 -> 0.20.9`                                                    |
| [`60b41214`](https://github.com/NixOS/nixpkgs/commit/60b41214de3fd70ebf55caeb981f97730ed361f7) | `librespot: 0.1.6 -> 0.2.0, remove Cargo lock`                                 |
| [`9cb52199`](https://github.com/NixOS/nixpkgs/commit/9cb521994ec836a8a76258bedef6fc1409710d0c) | `markets: 0.5.2 -> 0.5.3`                                                      |
| [`ab9bbad9`](https://github.com/NixOS/nixpkgs/commit/ab9bbad9ea45608591a431301fe3bdc603fe2874) | `orca: move python dependencies to pythonPath`                                 |
| [`45bf279e`](https://github.com/NixOS/nixpkgs/commit/45bf279eaa46a923eef23258db5ae8af4ad555b1) | `gnome.gnome-tweaks: move python dependencies to pythonPath`                   |
| [`c70619ee`](https://github.com/NixOS/nixpkgs/commit/c70619eec8aefc4e4620eb5543bf10f93d4dedd8) | `python38Packages.pglast: 3.6 -> 3.7`                                          |
| [`34573601`](https://github.com/NixOS/nixpkgs/commit/345736016811b4109e92dd9802ccccc191e99356) | `mod_dnssd: strip debugging symbols`                                           |
| [`9922d633`](https://github.com/NixOS/nixpkgs/commit/9922d6335511cdc9404a425f904b68a3063eda17) | `mod_dnssd: run {pre,post}Install hooks`                                       |
| [`a6bff35d`](https://github.com/NixOS/nixpkgs/commit/a6bff35d96b893f3b4ba378c7af086901493ae3a) | `lowdown: 0.9.0 -> 0.9.2`                                                      |
| [`c70f4c84`](https://github.com/NixOS/nixpkgs/commit/c70f4c843d31e20d6673e4d63fdd40f4f9b7132c) | `gnome.gnome-music: fix double wrapping`                                       |
| [`054d6d94`](https://github.com/NixOS/nixpkgs/commit/054d6d948618c292c04555323c06b64690318e3d) | `netplan: 0.101 -> 0.103, fix package`                                         |
| [`851b719a`](https://github.com/NixOS/nixpkgs/commit/851b719ac6bea528908fae1ec3ec9e0efae82e84) | `treewide: use stdenv.hostPlatform.extensions.sharedLibrary where appropriate` |
| [`7ff58e4a`](https://github.com/NixOS/nixpkgs/commit/7ff58e4a86d10d699fad1459c640ca87ede4a387) | `busybox: use more featureful modprobe by default`                             |
| [`c273fe92`](https://github.com/NixOS/nixpkgs/commit/c273fe92de41e3d2e6a7e0277e218dc0b8eb4b0e) | `php.packages.phpstan: 0.12.90 -> 0.12.99`                                     |
| [`ce639ad2`](https://github.com/NixOS/nixpkgs/commit/ce639ad2d5cdd76cdd7dac77bc9c81a31e71943f) | `gnome.gnome-music: move python dependencies to pythonPath`                    |
| [`b479d8e6`](https://github.com/NixOS/nixpkgs/commit/b479d8e6a5ca1b6359ad687bcf3555592ff34545) | `mate.mate-user-share: fix apache module path`                                 |
| [`22ab8492`](https://github.com/NixOS/nixpkgs/commit/22ab849288cabab48edcbfeb85271570ad9bffe1) | `gnome.gnome-user-share: fix apache module path`                               |
| [`bc21b6e5`](https://github.com/NixOS/nixpkgs/commit/bc21b6e58bde64093b332fbf52e53de68b8a27be) | `xstow: init at 1.0.2`                                                         |
| [`4b692c74`](https://github.com/NixOS/nixpkgs/commit/4b692c74acee25a9f1ad65664874f36173af07a5) | `maintainers: add nzbr`                                                        |
| [`050a1d0a`](https://github.com/NixOS/nixpkgs/commit/050a1d0a6e7b40d67742c3870f00bac05ac859f1) | `python3.pkgs.dogtail: add dev output`                                         |
| [`758fa385`](https://github.com/NixOS/nixpkgs/commit/758fa38581f8c2b62b46ebf2c044c9ed9b234862) | `python3.pkgs.dogtail: add dev output`                                         |
| [`4d526f3c`](https://github.com/NixOS/nixpkgs/commit/4d526f3c3e0adfa3cd85a5f183ddcb62af851738) | `emacsPackages.rec-mode: init at 1.8`                                          |
| [`dc6d7cd3`](https://github.com/NixOS/nixpkgs/commit/dc6d7cd3f0bbde277b96fffa3da0c9ccb06fb60f) | `adwaita-qt: add dev output`                                                   |
| [`5e175ea1`](https://github.com/NixOS/nixpkgs/commit/5e175ea138cb75949dd54f91d0335dfb1aaa08fc) | `python3Packages.aioesphomeapi: 9.1.5 -> 10.0.0`                               |
| [`96e249e1`](https://github.com/NixOS/nixpkgs/commit/96e249e1da5a06ca08cf12c4f07ef2875ddb130e) | `nerdctl: 0.11.2 -> 0.12.1`                                                    |
| [`e7cc807d`](https://github.com/NixOS/nixpkgs/commit/e7cc807d1ab97ccec20e052444b3f3f2e4190485) | `postman: 9.0.4 -> 9.0.5`                                                      |
| [`7ae3ae5a`](https://github.com/NixOS/nixpkgs/commit/7ae3ae5aabe660cb727d3e14cb247ac1509c7705) | `libgxps: add dev output`                                                      |
| [`871e855c`](https://github.com/NixOS/nixpkgs/commit/871e855cb78c43651b993264a539d28aa03c810e) | `gnome.nautilus: add dev output`                                               |
| [`311aeae8`](https://github.com/NixOS/nixpkgs/commit/311aeae8f18867f9d15862951201772fd46b35da) | `teleport: 7.2.0 -> 7.3.0`                                                     |
| [`305ea3e9`](https://github.com/NixOS/nixpkgs/commit/305ea3e9ede5429f2902c1543397cfb60db03e28) | `nixos/nvidia: fix typo in PM assert`                                          |
| [`f1220d72`](https://github.com/NixOS/nixpkgs/commit/f1220d72a3a06b0fbac1999b5c8a097d1d10cc0f) | `terraform-providers.kubernetes: 2.4.1 -> 2.5.0 (#141519)`                     |
| [`be9b2e54`](https://github.com/NixOS/nixpkgs/commit/be9b2e545d1be7dd7578ce65ffc3a484d00d0dd5) | `dockle: 0.4.2 -> 0.4.3`                                                       |
| [`32555b62`](https://github.com/NixOS/nixpkgs/commit/32555b6200825b8301742c0e8f00b562bf16a050) | `gzdoom: 4.5.0 -> 4.7.0`                                                       |
| [`49570f73`](https://github.com/NixOS/nixpkgs/commit/49570f737620d85af51a8ba9f4fde21b9eb1f5ab) | `python38Packages.mypy-boto3-s3: 1.18.59 -> 1.18.60`                           |
| [`f08d3daa`](https://github.com/NixOS/nixpkgs/commit/f08d3daab03decf14169dde35d0e24a2acd9ec3a) | `cargo-spellcheck: 0.8.13 -> 0.8.14`                                           |
| [`aa0a596e`](https://github.com/NixOS/nixpkgs/commit/aa0a596e6c2399cc1bc5f29e850d49ef6eccbc7e) | `csound: build with fluidsynth 2.x`                                            |
| [`d624bd14`](https://github.com/NixOS/nixpkgs/commit/d624bd148b5e0c673d5773b8a42e5f58e125c846) | `postman: 8.10.0 -> 9.0.4`                                                     |
| [`e2b72ec6`](https://github.com/NixOS/nixpkgs/commit/e2b72ec679a8485ce557c430df7d7b863f124a49) | `gitkraken: 7.8.1 -> 8.0.1`                                                    |
| [`a7cd8194`](https://github.com/NixOS/nixpkgs/commit/a7cd81947a8c5c5c51f14b81073ed2a8a46d788f) | `vivaldi: 4.1.2369.21-1 -> 4.3.2439.44-1`                                      |
| [`f584d169`](https://github.com/NixOS/nixpkgs/commit/f584d169ac57c319ef3ac0370a5df23b38f16f98) | `python38Packages.progressbar2: 3.53.3 -> 3.54.0`                              |
| [`b290f43a`](https://github.com/NixOS/nixpkgs/commit/b290f43a462dc332f7a58da9b867bb8f4a4581b1) | `skypeforlinux: 8.75.0.140 -> 8.77.0.97`                                       |
| [`b1d4b2b1`](https://github.com/NixOS/nixpkgs/commit/b1d4b2b1a66acd18945982ac1f1fbb90451c2543) | `python38Packages.google-cloud-os-config: 1.5.1 -> 1.6.0`                      |
| [`627a4b80`](https://github.com/NixOS/nixpkgs/commit/627a4b8085ad7ceb43023698758c2d791e28ab99) | `python38Packages.google-cloud-org-policy: 1.0.2 -> 1.1.0`                     |
| [`9c894ed3`](https://github.com/NixOS/nixpkgs/commit/9c894ed30a1f5eeb56ee3546f45e8a1cb7b633e4) | `python38Packages.google-cloud-language: 2.2.2 -> 2.3.0`                       |
| [`83be5a21`](https://github.com/NixOS/nixpkgs/commit/83be5a213c4f20922f8bdc3c1eba7ae9eb0fd090) | `python38Packages.google-cloud-iam: 2.3.2 -> 2.4.0`                            |
| [`3765d809`](https://github.com/NixOS/nixpkgs/commit/3765d809530091ac1309696aab64dfb66ba9d7a8) | `python38Packages.google-cloud-dns: 0.33.1 -> 0.34.0`                          |
| [`80f13fb9`](https://github.com/NixOS/nixpkgs/commit/80f13fb93d8c432595901f7970efc1bc4a42be28) | `deno: 1.15.0 -> 1.15.1`                                                       |
| [`2431d1cc`](https://github.com/NixOS/nixpkgs/commit/2431d1cceb68ecf224fdec5f13d4b391dd75e77b) | `python38Packages.google-cloud-bigquery-logging: 0.2.2 -> 1.0.0`               |
| [`ebf1fdff`](https://github.com/NixOS/nixpkgs/commit/ebf1fdffde747d52c03cae794cbde6fb599a75d4) | `python38Packages.google-cloud-bigquery-datatransfer: 3.3.4 -> 3.4.0`          |
| [`0ff9c5e3`](https://github.com/NixOS/nixpkgs/commit/0ff9c5e3e2580d40699e49ce6d9eb3e909a7b330) | `python38Packages.google-cloud-appengine-logging: 0.1.5 -> 1.0.0`              |
| [`8fe5e8f4`](https://github.com/NixOS/nixpkgs/commit/8fe5e8f4a81e5442b07fb1e853e55a882f3f0b6f) | `exploitdb: 2021-10-09 -> 2021-10-13`                                          |