### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bc12543f329c4db811213652fd95f88fa3c7e8f2",
-        "sha256": "0j2plagmh9i1sc2b3p00vq21c5ks2mg5f68c1zs51k5wbm8ig2qn",
+        "rev": "7b47000f84ccc4061c053c1cc92bc172a6b814da",
+        "sha256": "14c7nvlzsn6lbkqpyr6kblzvsbx5vdzy21gskrj1d2wv7dqg50x0",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/bc12543f329c4db811213652fd95f88fa3c7e8f2.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/7b47000f84ccc4061c053c1cc92bc172a6b814da.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                             |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`aac4c425`](https://github.com/NixOS/nixpkgs/commit/aac4c4255170bea9ab0dcead1f2a9e25de9492ac) | `nixos/doc/manual/release_notes: add kernelParams notes`                   |
| [`a868222d`](https://github.com/NixOS/nixpkgs/commit/a868222d6504e0af76fc98716a679f19651ec920) | `nixos.system.boot.kernel: stronger constraints for kernelParam type`      |
| [`df1531f3`](https://github.com/NixOS/nixpkgs/commit/df1531f3dc0ed37b82bb11a96fdbae9e076bf429) | `chromiumDev: 96.0.4662.6 -> 96.0.4664.9`                                  |
| [`b946b0f9`](https://github.com/NixOS/nixpkgs/commit/b946b0f9bb92b9988f745cfaca82f9c09d571c25) | `coqPackages.goedel: 8.12.0 -> 8.13.0`                                     |
| [`ae522fb7`](https://github.com/NixOS/nixpkgs/commit/ae522fb7f98cb92f8ac92df91ac0be8b02fb33ee) | `chromium: Drop Python 2`                                                  |
| [`91f13a55`](https://github.com/NixOS/nixpkgs/commit/91f13a5581fb809bfeae2a48f5b9e710d7ce4867) | `tutanota-desktop: install from release tarball (#140921)`                 |
| [`27c51b5c`](https://github.com/NixOS/nixpkgs/commit/27c51b5ccc84956f61adc17727693cda19872dd3) | `tlp: 1.3.1 -> 1.4.0`                                                      |
| [`e242eef8`](https://github.com/NixOS/nixpkgs/commit/e242eef8a45f7e149f7af64ae07e0c45ab51c044) | `coq_8_14: 8.14+rc1 -> 8.14.0`                                             |
| [`cbf28fa8`](https://github.com/NixOS/nixpkgs/commit/cbf28fa8c482f4e7add90532b18761b49771cf99) | `ligo: init at 0.26`                                                       |
| [`4a1558f2`](https://github.com/NixOS/nixpkgs/commit/4a1558f2900634e455fd7aff43106586c95c0b23) | `terraform-provider-vault: 2.11.0 -> 2.24.1`                               |
| [`c389ff16`](https://github.com/NixOS/nixpkgs/commit/c389ff1626c9118eac98a4208a493a082ae2f75d) | `ashpd-demo: init at 0.0.1-alpha`                                          |
| [`7d50491a`](https://github.com/NixOS/nixpkgs/commit/7d50491a19c599abaff0933cf981272fdb82a73c) | `python3Packages.vt-py: 0.7.5 -> 0.7.6`                                    |
| [`70c07a17`](https://github.com/NixOS/nixpkgs/commit/70c07a17fb04dfbb75932b3c4a53fe593a653d20) | `profanity: 0.11.0 -> 0.11.1`                                              |
| [`62813808`](https://github.com/NixOS/nixpkgs/commit/62813808ff0d9feb202a458766de23ea897a60e6) | `nixos/unifi, unifi: add pennae to maintainers`                            |
| [`97719b92`](https://github.com/NixOS/nixpkgs/commit/97719b92f9750343ffc4a0776d08cac29b61cce4) | `maintainers: add pennae`                                                  |
| [`a3d711f4`](https://github.com/NixOS/nixpkgs/commit/a3d711f4e1d99a5b11428c868b4701eeb18b6102) | `nixos/gdm: remove obsolete pulseaudio module`                             |
| [`960ae854`](https://github.com/NixOS/nixpkgs/commit/960ae854b587bc81cf5e6e9638779f908ac81a58) | `swtpm: improvements for use with libvirt`                                 |
| [`3ab9c20b`](https://github.com/NixOS/nixpkgs/commit/3ab9c20bb69ec9128edd85519ba7e07d313c2e55) | `kopia: 0.9.0 -> 0.9.2`                                                    |
| [`7fa82abe`](https://github.com/NixOS/nixpkgs/commit/7fa82abed7a0971bebbd4c45570359fbddd8cb8e) | `.github/CODEOWNERS: add zakame to perl maintainers`                       |
| [`50b636fd`](https://github.com/NixOS/nixpkgs/commit/50b636fd0efeccc6b60f60e61d85ce1140bfaa40) | `vscodium: 1.61.0 -> 1.61.1`                                               |
| [`0b14dd06`](https://github.com/NixOS/nixpkgs/commit/0b14dd0686c7111b6dbb8aebe9af9b0907f63bc7) | `oha: 0.4.6 -> 0.4.7`                                                      |
| [`a3666238`](https://github.com/NixOS/nixpkgs/commit/a3666238bdb88cef6d0403c565753c98588945a1) | `haskellPackages: mark builds failing on hydra as broken`                  |
| [`7effa9bc`](https://github.com/NixOS/nixpkgs/commit/7effa9bcb1af8b4e8361c5b73d59560ba68a33d1) | `gitui: 0.17.1 -> 0.18.0`                                                  |
| [`c8767246`](https://github.com/NixOS/nixpkgs/commit/c87672464e14ceb095be1097bd7d44dc5bc3effc) | `metasploit: 6.1.9 -> 6.1.10`                                              |
| [`5c339ff4`](https://github.com/NixOS/nixpkgs/commit/5c339ff41eda06cfdf0d21e692b033a2973d8a61) | `netlify-cli: Fix by using explicit esbuild fork package`                  |
| [`e8c67529`](https://github.com/NixOS/nixpkgs/commit/e8c67529a53bbf1c8746ad98ec7365981ae6bb5b) | `esbuild_netlify: init`                                                    |
| [`91a115ab`](https://github.com/NixOS/nixpkgs/commit/91a115abfa847b043ba81a841323ac2f804fd108) | `python38Packages.google-cloud-redis: 2.2.4 -> 2.3.0`                      |
| [`5aa3a758`](https://github.com/NixOS/nixpkgs/commit/5aa3a7581c330e40c3d2ad49641f7d1693ea61a2) | `kubescape: 1.0.109 -> 1.0.120`                                            |
| [`55205d57`](https://github.com/NixOS/nixpkgs/commit/55205d5739d4be258c28e17fc54cce530d405480) | `emacs-sv-kalender: 1.9 -> 1.11`                                           |
| [`fbfd869f`](https://github.com/NixOS/nixpkgs/commit/fbfd869f90bed728217ceba4ed0a30cab2e97b38) | `python38Packages.google-cloud-translate: 3.4.1 -> 3.5.0`                  |
| [`35904b1c`](https://github.com/NixOS/nixpkgs/commit/35904b1c438ead51203126770107912c544773fe) | `python38Packages.google-cloud-asset: 3.6.1 -> 3.7.0`                      |
| [`eec90bc9`](https://github.com/NixOS/nixpkgs/commit/eec90bc9d5d6866517ba851c2e798e70286080b4) | `luarocks: 3.2.1 -> 3.7.0`                                                 |
| [`db3873c6`](https://github.com/NixOS/nixpkgs/commit/db3873c6fb724cec667d8fd7cd4ed91a07b4d5fd) | `python38Packages.google-cloud-kms: 2.8.0 -> 2.9.0`                        |
| [`f0d3f99c`](https://github.com/NixOS/nixpkgs/commit/f0d3f99c4d12ddb20d3c924b232ab55e1d8ff4f3) | `python38Packages.google-cloud-vision: 2.4.4 -> 2.5.0`                     |
| [`6a4f430d`](https://github.com/NixOS/nixpkgs/commit/6a4f430dab0104cfa03100e7eed49c4010444a64) | `python38Packages.google-cloud-redis: 2.2.4 -> 2.3.0`                      |
| [`e8d0afd8`](https://github.com/NixOS/nixpkgs/commit/e8d0afd8d198b8f7c7c15e89cb842cf00551499f) | `nixos/sickbeard: fix the startup command`                                 |
| [`0c994080`](https://github.com/NixOS/nixpkgs/commit/0c9940801844c2cfed0c5eebe7c5f306f1b2bb0e) | `headphones: 0.5.19 -> 0.5.20`                                             |
| [`a22dea95`](https://github.com/NixOS/nixpkgs/commit/a22dea955eaf22fcbb5fd5a47db357c956c4b98d) | `python38Packages.fido2: 0.9.1 -> 0.9.2`                                   |
| [`0242265e`](https://github.com/NixOS/nixpkgs/commit/0242265e551d0ea9f674bf771065f353f780b1a5) | `nixos/plasma5: add useQtScaling option`                                   |
| [`4ad48d25`](https://github.com/NixOS/nixpkgs/commit/4ad48d2517ce96fa8d93fdf76e5190eda6972b0e) | `fnott: 1.1.0 -> 1.1.2`                                                    |
| [`4e42c300`](https://github.com/NixOS/nixpkgs/commit/4e42c3008c787cacbf110b5ccb0aaf84935b020f) | `treewide: clean up fedorahosted.org URLs (#139977)`                       |
| [`a2fa0691`](https://github.com/NixOS/nixpkgs/commit/a2fa0691038f9012c1744652583736d5f9b9b87f) | `rstudio: 1.2.5042 -> 1.4.1717`                                            |
| [`8960ed15`](https://github.com/NixOS/nixpkgs/commit/8960ed15aefcb550bb66873eccbb402ad0480f2a) | `libwnck: 3.36.0 → 40.0`                                                   |
| [`b399f77c`](https://github.com/NixOS/nixpkgs/commit/b399f77c38b76560ad224471fc00e20a60f65cec) | `gnome-builder: 3.40.2 → 41.1`                                             |
| [`b341f3bb`](https://github.com/NixOS/nixpkgs/commit/b341f3bb43467049a43091c10959040a383d1f00) | `libsigcxx: 2.10.6 → 2.10.7`                                               |
| [`e38bc6d8`](https://github.com/NixOS/nixpkgs/commit/e38bc6d806ea6d1c019e7be12ce60468c0f4246e) | `yelp-tools: 40.0 → 41.0`                                                  |
| [`dcdfc8ee`](https://github.com/NixOS/nixpkgs/commit/dcdfc8ee2531ef5e277c796d747aa7257b683e3a) | `tracker-miners: 3.1.1 → 3.2.0`                                            |
| [`129ee8b1`](https://github.com/NixOS/nixpkgs/commit/129ee8b18e109926b239b2b2ea13c7007978170d) | `gtkmm4: 4.2.0 → 4.4.0`                                                    |
| [`9ed32d8d`](https://github.com/NixOS/nixpkgs/commit/9ed32d8d858a7a131e0f0ea8c820409a160ee8e0) | `gthumb: 3.11.4 → 3.12.0`                                                  |
| [`f6acbbfe`](https://github.com/NixOS/nixpkgs/commit/f6acbbfe399bc02f65592ab3fa9c381140e066b8) | `grilo-plugins: 0.3.13 → 0.3.14`                                           |
| [`50eac60d`](https://github.com/NixOS/nixpkgs/commit/50eac60da0fbc1432b89434c9a1025877e513da9) | `grilo: 0.3.13 → 0.3.14`                                                   |
| [`07548397`](https://github.com/NixOS/nixpkgs/commit/075483973b5449d7c9df38e7217c01690cbaa019) | `gnome-connections: 40.0.1 → 41.0`                                         |
| [`3ba01756`](https://github.com/NixOS/nixpkgs/commit/3ba01756f9fc0a2e99e87e7e557629bd1f3f8cc3) | `gtk-frdp: 3.37.1-unstable-2020-10-26 → unstable-2021-10-01`               |
| [`a2bdb822`](https://github.com/NixOS/nixpkgs/commit/a2bdb822a85dadfe48815c9b0930f2affd78777a) | `gnome.totem: 3.38.1 → 3.38.2`                                             |
| [`01031cec`](https://github.com/NixOS/nixpkgs/commit/01031cec26bf9cda82336f1cb97ac59be533a4b0) | `glibmm_2_68: 2.68.1 → 2.70.0`                                             |
| [`26d81d2f`](https://github.com/NixOS/nixpkgs/commit/26d81d2ffe6b419b4843379f1c180fe08b902e09) | `glibmm: 2.66.1 → 2.66.2`                                                  |
| [`e4fa9334`](https://github.com/NixOS/nixpkgs/commit/e4fa9334336b5b819125b080c516fa5448d32ebd) | `gexiv2: 0.12.3 → 0.14.0`                                                  |
| [`7529664f`](https://github.com/NixOS/nixpkgs/commit/7529664ff5ac0aca7036fbf7857e65545a89ea3c) | `flexget: 3.1.137 -> 3.1.138`                                              |
| [`6924f1ed`](https://github.com/NixOS/nixpkgs/commit/6924f1edff7fcb2d712a9b7c87b80a87ea8d9411) | `android-studio-canary: 2021.1.1.13 → 2021.2.1.1`                          |
| [`f75ead8a`](https://github.com/NixOS/nixpkgs/commit/f75ead8a51dfde1d1ec9656bf20078fdc460987b) | `android-studio-beta: 2020.3.1.21 → 2021.1.1.14`                           |
| [`42e947ee`](https://github.com/NixOS/nixpkgs/commit/42e947eee2bccf0bf964a4101464bf0def30e008) | `evince: 40.4 → 41.2`                                                      |
| [`747e50e5`](https://github.com/NixOS/nixpkgs/commit/747e50e5da50df24810f8abd7c3101b12608bd7f) | `orca: 40.0 → 41.0`                                                        |
| [`fcce6ede`](https://github.com/NixOS/nixpkgs/commit/fcce6ede95d6f5e820a069227a9ec7b0e482ed5b) | `gnome.gucharmap: use nix-update updater`                                  |
| [`6db50236`](https://github.com/NixOS/nixpkgs/commit/6db50236ef460b3a1294efd6e8a3a594d1f024ff) | `goocanvasmm2.updateScript: change version policy`                         |
| [`2c39b38b`](https://github.com/NixOS/nixpkgs/commit/2c39b38b6e117b388253e0b6a8f4f179baaaae4f) | `goocanvas.updateScript: freeze ABI at 1.0`                                |
| [`7f0259b4`](https://github.com/NixOS/nixpkgs/commit/7f0259b4c83d8d28ab8a44ab31b639525c21f912) | `goocanvas3: add updateScript`                                             |
| [`9dda958c`](https://github.com/NixOS/nixpkgs/commit/9dda958c3a949bf6447355fc56c8aaaf7d7e6bf6) | `goocanvas2: add updateScript`                                             |
| [`6e984639`](https://github.com/NixOS/nixpkgs/commit/6e98463923326a48725a65c621d01fc280aedfcc) | `gstreamermm.updateScript: correct attribute path`                         |
| [`ca2d815d`](https://github.com/NixOS/nixpkgs/commit/ca2d815d5805da4d2e77b7f3a2548bd2eecf6375) | `libxmlxx3: add updateScript`                                              |
| [`92aca820`](https://github.com/NixOS/nixpkgs/commit/92aca820b26f5310e1272eb086757f42d0707e39) | `libxmlxx.updateScript: correct attribute path`                            |
| [`a48c2490`](https://github.com/NixOS/nixpkgs/commit/a48c24906d5c75e65bf888b0929150a8d50aa24b) | `libwnck.updateScript: correct attribute path`                             |
| [`d2b9122a`](https://github.com/NixOS/nixpkgs/commit/d2b9122a290c91ae554e1022ab8b8324bd1656d1) | `libsoup_3.updateScript: correct attribute path`                           |
| [`4231aad6`](https://github.com/NixOS/nixpkgs/commit/4231aad62414f30542ecfc6b6fafa9e52b17d967) | `libsigcxx.updateScript: freze at 3.0 ABI version`                         |
| [`3801cfb2`](https://github.com/NixOS/nixpkgs/commit/3801cfb22c20007d13c1bd592d42bb7081a15cdf) | `libgda.updateScript: freze at 5.0 ABI version`                            |
| [`26b4b39f`](https://github.com/NixOS/nixpkgs/commit/26b4b39f4cddd41c9355388d2d97dc457cfdd7e8) | `gtksourceviewmm.updateScript: freze at 3.0 ABI version`                   |
| [`b9534880`](https://github.com/NixOS/nixpkgs/commit/b95348806e5a9d825394c418de1ab1c89dcadc3c) | `gtksourceview4.updateScript: freze at 4.0 ABI version`                    |
| [`3b2a64d5`](https://github.com/NixOS/nixpkgs/commit/3b2a64d52355ac6371de6c57d025d1dd851dfa76) | `gtkmm3.updateScript: freze at 3.0 ABI version`                            |
| [`e7934867`](https://github.com/NixOS/nixpkgs/commit/e7934867a83441659733df00f98f9d6cba18b082) | `gtk3.updateScript: freze at 3.0 ABI version`                              |
| [`9e6cb6d6`](https://github.com/NixOS/nixpkgs/commit/9e6cb6d608393d9629e6eb594c85e6575a1c8ce4) | `atkmm_2_36.updateScript.updateScript: correct attribute path`             |
| [`ca62f595`](https://github.com/NixOS/nixpkgs/commit/ca62f59516894db946698fc17e2b3faac68e4eb9) | `vala.updateScript: freze at current ABI version`                          |
| [`c051a811`](https://github.com/NixOS/nixpkgs/commit/c051a81161feee4cff1f15175b889737d6555dfe) | `libsoup.updateScript: freze at 2.4 ABI version`                           |
| [`ad182ff2`](https://github.com/NixOS/nixpkgs/commit/ad182ff274c9ec7f3233368171cc8f379b9cf3cf) | `meld.updateScript: remove version policy`                                 |
| [`f3a20a32`](https://github.com/NixOS/nixpkgs/commit/f3a20a323100e136522b494aa2dd79cbe3074fa7) | `gtksourceviewmm4.updateScript: correct attribute path`                    |
| [`98a7fc82`](https://github.com/NixOS/nixpkgs/commit/98a7fc82a9f9a0ee2fbb3c9b5a0f88fe12c2a2cf) | `libgdamm.updateScript: remove version policy`                             |
| [`be373504`](https://github.com/NixOS/nixpkgs/commit/be373504e281ca13a42a7c16d746b1af0f82f083) | `nomad_1_1: 1.1.5 -> 1.1.6`                                                |
| [`973f851c`](https://github.com/NixOS/nixpkgs/commit/973f851c0bd5f8eeb9d9d575ea6852754968cf66) | `nomad_1_0: 1.0.11 -> 1.0.12`                                              |
| [`d8a98827`](https://github.com/NixOS/nixpkgs/commit/d8a98827b886680302e255aa18ce528eb4d6fd94) | `vault-bin: 1.8.3 -> 1.8.4`                                                |
| [`e703a8e5`](https://github.com/NixOS/nixpkgs/commit/e703a8e5d737006061e26aa676f503cc5c320c01) | `vault: 1.8.3 -> 1.8.4`                                                    |
| [`d7e522e8`](https://github.com/NixOS/nixpkgs/commit/d7e522e8032c1774cf65f0cb07ab935340971d7f) | `chromiumBeta: 95.0.4638.40 -> 95.0.4638.49`                               |
| [`4f1b5073`](https://github.com/NixOS/nixpkgs/commit/4f1b50734dc89dccd68dc53f091596d06ede5ca9) | `perlPackages.GraphicsColor: init at 0.31`                                 |
| [`6e70f7c3`](https://github.com/NixOS/nixpkgs/commit/6e70f7c3364d29ef9aa7fee55a87cc46b176d944) | `perlPackages.JSONParse: 0.57 -> 0.61`                                     |
| [`d5caa52d`](https://github.com/NixOS/nixpkgs/commit/d5caa52d82fd038201b060ddc7c0ef1003854df8) | `perlPackages.URIEscapeXS: init at 0.14`                                   |
| [`26754d7a`](https://github.com/NixOS/nixpkgs/commit/26754d7ab4de3953d72503ac28e086e15188d84e) | `perlPackages.LocaleMaketextLexiconGetcontext: init at 0.05`               |
| [`be3f7229`](https://github.com/NixOS/nixpkgs/commit/be3f72291ff41d61e9c5759839039d6420b5a2e3) | `perlPackages.TypeTinyXS: init at 0.022`                                   |
| [`88a3bd0b`](https://github.com/NixOS/nixpkgs/commit/88a3bd0ba569f0c805d3f0b7193ddbb45480c330) | `perlPackages.BSONXS: init at 0.8.4`                                       |
| [`ce32331a`](https://github.com/NixOS/nixpkgs/commit/ce32331a1d68382f5a5937a36ac4e2d66ff00293) | `perlPackages.TimeMoment: init at 0.44`                                    |
| [`1537f81a`](https://github.com/NixOS/nixpkgs/commit/1537f81a630b4db69441acb255b64514d121558b) | `perlPackages.MooseXStorageFormatJSONpm: init at 0.093093`                 |
| [`d624b271`](https://github.com/NixOS/nixpkgs/commit/d624b2717617d9f0a7adad0dee7abfd4deac124e) | `perlPackages.YAMLOld: init at 1.23`                                       |
| [`df2b12d5`](https://github.com/NixOS/nixpkgs/commit/df2b12d5722d9fddcc0d18781c181d483f8ec4f4) | `perlPackages.TestDeepJSON: init at 0.05`                                  |
| [`962407c6`](https://github.com/NixOS/nixpkgs/commit/962407c6608808b0f3eca52d268fe5b1e37de907) | `perlPackages.ApacheDB: init at 0.18`                                      |
| [`680ed2e7`](https://github.com/NixOS/nixpkgs/commit/680ed2e7c7a6717fe2e0e3a8487b9e4325c89a26) | `perlPackages.LogAnyAdapterTAP: init at 0.003003`                          |
| [`f8d9a395`](https://github.com/NixOS/nixpkgs/commit/f8d9a395227189b8bff1c155108b5a51610d2665) | `perlPackages.UUIDURandom: init at 0.001`                                  |
| [`db66f2d0`](https://github.com/NixOS/nixpkgs/commit/db66f2d06691496c1a32976cbb0612912172c334) | `perlPackages.BSON: init at 1.12.2`                                        |
| [`8c3f1c8e`](https://github.com/NixOS/nixpkgs/commit/8c3f1c8e388bd6908646f8cc6af10d403d812920) | `perlPackages.Linuxusermod: init at 0.69`                                  |
| [`5898efe9`](https://github.com/NixOS/nixpkgs/commit/5898efe9225ce4b42e7dfcb6ab394a7c01c731c2) | `perlPackages.LEOCHARREDebug: init at 1.03`                                |
| [`ba8492c9`](https://github.com/NixOS/nixpkgs/commit/ba8492c92db950d2a6cb9671b22f7cc8e189d079) | `perlPackages.LEOCHARRECLI: init at 1.19`                                  |
| [`9a0fb7f6`](https://github.com/NixOS/nixpkgs/commit/9a0fb7f676b47d62e0c22e121c8e28064fbe6e89) | `perlPackages.TestDeepType: init at 0.008`                                 |
| [`ba41966c`](https://github.com/NixOS/nixpkgs/commit/ba41966cb847fa9f37ba7d0c60854a9d6a91c452) | `perlPackages.MooseXStorage: init at 0.53`                                 |
| [`e4eb6e52`](https://github.com/NixOS/nixpkgs/commit/e4eb6e52823c9eac6f14f71e8a59ed1a744dc0f9) | `perlPackages.ColorLibrary: init at 0.021`                                 |
| [`ab2ae072`](https://github.com/NixOS/nixpkgs/commit/ab2ae072b054d1bdd0405e5f6b7ab81edefd2d01) | `perlPackages.Filechmod: init at 0.42`                                     |
| [`55eeed8c`](https://github.com/NixOS/nixpkgs/commit/55eeed8ce556d2915d4624543be85f060d0fa6a4) | `perlPackages.IOInteractiveTiny: init at 0.2`                              |
| [`d272d0d2`](https://github.com/NixOS/nixpkgs/commit/d272d0d27c8f6aa8b6ea1273cb1d7462bfbb38c6) | `perlPackages.ModuleBuildPluggableCPANfile: init at 0.05`                  |
| [`2181d11c`](https://github.com/NixOS/nixpkgs/commit/2181d11cd75f2265ecd12c2ae7242e22ff43e098) | `perlPackages.MathFibonacci: init at 1.5`                                  |
| [`db9b6d29`](https://github.com/NixOS/nixpkgs/commit/db9b6d29e8b4cbb9f5a6fb7e13d2ad2626fdf9da) | `perlPackages.ActionRetry: init at 0.24`                                   |
| [`4e15e2a0`](https://github.com/NixOS/nixpkgs/commit/4e15e2a0f144a750db30fe5914bde054787e4657) | `perlPackages.ActionCircuitBreaker: init at 0.1`                           |
| [`bb592ff1`](https://github.com/NixOS/nixpkgs/commit/bb592ff146e5b8c5af02750d16b01306c5fce9dd) | `perlPackages.JSONCreate: init at 1.39`                                    |
| [`5c98976b`](https://github.com/NixOS/nixpkgs/commit/5c98976b90a7886289fc51f68074ff3216299207) | `perlPackages.DevelSize: init at 0.83`                                     |
| [`ae104c4d`](https://github.com/NixOS/nixpkgs/commit/ae104c4db4d6904343113a794f9ee913d9f96e7e) | `perlPackages.FilechmodRecursive: init at 1.0.3`                           |
| [`2deb8e1e`](https://github.com/NixOS/nixpkgs/commit/2deb8e1e7c188449a8e5fcc8c525902046d6e2ba) | `perlPackages.SpreadsheetCSV: init at 0.20`                                |
| [`d3df49e7`](https://github.com/NixOS/nixpkgs/commit/d3df49e7782e9e0c8d825eece30316cbcf1e08e5) | `perlPackages.TextFuzzy: init at 0.29`                                     |
| [`6fd8ff43`](https://github.com/NixOS/nixpkgs/commit/6fd8ff43896abb1407b2c15f0e16036ea2299935) | `perlPackages.XMLRules: init at 1.16`                                      |
| [`1e2f66e0`](https://github.com/NixOS/nixpkgs/commit/1e2f66e0f9dacb26b1fbd568c00dbe1b63a74a23) | `perlPackages.DataDumperAutoEncode: init at 1.00`                          |
| [`1df277ab`](https://github.com/NixOS/nixpkgs/commit/1df277ab64a5c68decad8667a5246fffca3d3ec1) | `perlPackages.CLDRNumber: init at 0.19`                                    |
| [`7d707c6e`](https://github.com/NixOS/nixpkgs/commit/7d707c6ef3a66aae355e21834483fd4d7c937080) | `perlPackages.ImageOCRTesseract: init at 1.26`                             |
| [`63e8ea56`](https://github.com/NixOS/nixpkgs/commit/63e8ea56dd2457c2fabb5071af879b4c9c92bd90) | `perlPackages.AlgorithmCheckDigits: init at 1.3.5`                         |
| [`2da91b27`](https://github.com/NixOS/nixpkgs/commit/2da91b27a3121ad55a02de1a8c417446dd937153) | `perlPackages.EncodePunycode: init at 1.002`                               |
| [`1a935cd3`](https://github.com/NixOS/nixpkgs/commit/1a935cd38006bfc358d768bd869a072b0ad21269) | `perlPackages.MongoDB: init at 2.2.2`                                      |
| [`446e1e18`](https://github.com/NixOS/nixpkgs/commit/446e1e18e7534c979a000a515e7828477898fcba) | `perlPackages.ExcelWriterXLSX: init at 1.09`                               |
| [`1984b89d`](https://github.com/NixOS/nixpkgs/commit/1984b89dfeaabefb854be94ac6309fb781b2b7f5) | `mousai: 0.4.2 -> 0.6.6`                                                   |
| [`28331311`](https://github.com/NixOS/nixpkgs/commit/28331311a337023fcc38cd4ad0c0d9a30ddcb67b) | `libadwaita: 1.0.0-alpha.2 -> 1.0.0.alpha.3`                               |
| [`d718a55d`](https://github.com/NixOS/nixpkgs/commit/d718a55db8ed21f7d9d155f3f7e58f64c398414f) | `python3Packages.cramjam: 2.3.2 -> 2.4.0, remove vendored Cargo.lock`      |
| [`88469b28`](https://github.com/NixOS/nixpkgs/commit/88469b284269424570e68f5cd220759c434e8972) | `plantuml: 1.2021.9 -> 1.2021.12`                                          |
| [`e2341edc`](https://github.com/NixOS/nixpkgs/commit/e2341edc1ea405f93acd74ab6c091cb107bd07f8) | `gnomeExtensions.dash-to-dock: unstable-2021-07-07 -> unstable-2021-10-03` |
| [`7cda65b8`](https://github.com/NixOS/nixpkgs/commit/7cda65b81a8883817f641b6f9922fc8e17ff2256) | `libyaml-cpp: apply patch to fix cmake variables`                          |
| [`5763d8c2`](https://github.com/NixOS/nixpkgs/commit/5763d8c2f4dc60dbc85ddfc09a9bd22d220f2189) | `liblinphone: add boost to buildinputs to fix build after`                 |
| [`2287fbeb`](https://github.com/NixOS/nixpkgs/commit/2287fbebc80f9c101f6406223e993471d3e1757c) | `lime: add boost to buildinputs to fix build after`                        |
| [`0b2d3bbf`](https://github.com/NixOS/nixpkgs/commit/0b2d3bbfcb986aead64f16ccb534f4d2c2a4ae16) | `yices: 2.6.3 -> 2.6.2`                                                    |
| [`0ea6aec9`](https://github.com/NixOS/nixpkgs/commit/0ea6aec9aa2ec39278bbbf8c632e20a8603a5ff7) | `directx-shader-compiler: 1.5.2010 -> 1.6.2106`                            |
| [`510de41d`](https://github.com/NixOS/nixpkgs/commit/510de41d3ec691f050f3d991f9fd0ccd26cc209e) | `python3Packages.binwalk: remove unneeded dependency ncompress`            |
| [`80dd2675`](https://github.com/NixOS/nixpkgs/commit/80dd267525b5a59828548d933574018c2adcce71) | `ncompress: modernize build and switch to a github source`                 |
| [`0e90a1f1`](https://github.com/NixOS/nixpkgs/commit/0e90a1f13d89507dead4397e9ff499a9c95b01e3) | `haskellPackages.weeder: downgrade to 2.2.0 to keep building`              |
| [`bde22ab9`](https://github.com/NixOS/nixpkgs/commit/bde22ab96ee446cb34f8f503cdea421b4208c217) | `haskellPackages.procex: only execute tests if Kernel >= 5.9`              |
| [`05482d2a`](https://github.com/NixOS/nixpkgs/commit/05482d2a1b6d3d22cdddd1eb386b826659f1f9be) | `haskellPackages.git-annex: update sha256 for 8.20211011`                  |
| [`6dcbb737`](https://github.com/NixOS/nixpkgs/commit/6dcbb73730385367297a1b910b819f41e5e842b5) | `mattermost-desktop: add libappindicator-gtk3 to rpath`                    |
| [`e8b84e80`](https://github.com/NixOS/nixpkgs/commit/e8b84e802c23efc0606badc72e4bd4e903096ed7) | `apycula: 0.0.1a9 -> 0.0.1a11`                                             |
| [`05f24599`](https://github.com/NixOS/nixpkgs/commit/05f24599159e7094166947baa923d25a9f4bc0f9) | `nixopsUnstable: 2.0.0-pre (2021-09-05) -> 2.0.0-pre (2021-10-12)`         |
| [`a4d1cc9c`](https://github.com/NixOS/nixpkgs/commit/a4d1cc9c23042fb0ee11e1313d16a888d35b9056) | `libvirt: 7.7.0 -> 7.8.0`                                                  |
| [`980f1408`](https://github.com/NixOS/nixpkgs/commit/980f14081fdf8d58809be28ff5f94cce4fe25967) | `soci: 4.0.1 -> 4.0.2 + build with postgresql and boost`                   |
| [`2f49e714`](https://github.com/NixOS/nixpkgs/commit/2f49e7148b212d8b7085f3915ecad2b76518ee0c) | `gl-gsync-demo: init at 2020-12-27`                                        |
| [`2fb806db`](https://github.com/NixOS/nixpkgs/commit/2fb806dba040bddd93d87e054b88a65c42976dc4) | `haskell.packages.*: reflect Cabal minor version update`                   |
| [`28cfb685`](https://github.com/NixOS/nixpkgs/commit/28cfb685ee089c3e9fab21bd7902c18bde1734b4) | `haskellPackages: regenerate package set based on current config`          |
| [`59203105`](https://github.com/NixOS/nixpkgs/commit/592031058465278bb94a9d94714d8618a4abf588) | `haskellPackages: regenerate package set based on current config`          |
| [`8fad89e4`](https://github.com/NixOS/nixpkgs/commit/8fad89e4a3bef852b294aa0bc96c8c8c6d939ec4) | `all-cabal-hashes: 2021-10-08T09:46:02Z -> 2021-10-11T20:00:11Z`           |
| [`dea3e6b6`](https://github.com/NixOS/nixpkgs/commit/dea3e6b6bc597370bd05e50ad2e8c19d181b5b58) | `haskellPackages.functor-combinators: unbreak`                             |
| [`1fc860b9`](https://github.com/NixOS/nixpkgs/commit/1fc860b9ede1dfa95a7eefdc34e890e822006d4f) | `lutris: propagate important meta attrs to FHSEnv wrapper`                 |
| [`2c6f1164`](https://github.com/NixOS/nixpkgs/commit/2c6f116448287a065b7e2b37686dc82b363de35a) | `llvmPackages_13, llvmPackages_git: libcxxabi: fix musl build`             |
| [`c2f56cea`](https://github.com/NixOS/nixpkgs/commit/c2f56ceacceeb2a466d1c6b26c6a4be149a18a39) | `usbredir: 0.10.0 -> 0.11.0`                                               |
| [`d69bb5f6`](https://github.com/NixOS/nixpkgs/commit/d69bb5f6bafd7596e7e62458e7496b097083d367) | `perlPackages.XMLEncoding: init at 2.11`                                   |
| [`58921a49`](https://github.com/NixOS/nixpkgs/commit/58921a49040285b76da8575fc3dd3d41fc42f895) | `nixos/nix-daemon: assert system or systems for buildMachines.`            |