### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7b47000f84ccc4061c053c1cc92bc172a6b814da",
-        "sha256": "14c7nvlzsn6lbkqpyr6kblzvsbx5vdzy21gskrj1d2wv7dqg50x0",
+        "rev": "0478f8b360288a4be8c71bf11e42fcaf09b8b773",
+        "sha256": "0ajd2lzsjxw2zdc35a5xw8ci0k5vizj63xvxnpya2m45wr9dn5rj",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/7b47000f84ccc4061c053c1cc92bc172a6b814da.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/0478f8b360288a4be8c71bf11e42fcaf09b8b773.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                    |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`3c6e3c74`](https://github.com/NixOS/nixpkgs/commit/3c6e3c742fbbc28a9ee6bb4840d9f88957c75d42) | `coqPackages.mathcomp-zify: 1.0.0+1.12+8.13 -> 1.1.0+1.12+8.13`   |
| [`4b26811c`](https://github.com/NixOS/nixpkgs/commit/4b26811cdd7568e7ad331186f82009e60c882eb9) | `coqPackages.gaia: mark as compatible with Coq 8.14`              |
| [`3ee5dff7`](https://github.com/NixOS/nixpkgs/commit/3ee5dff79e6feb748597c8aaabe9ec47c389ff83) | `tflint: 0.32.1 -> 0.33.0`                                        |
| [`07c44a2d`](https://github.com/NixOS/nixpkgs/commit/07c44a2d31e3becd566b6380d1873852262f11a2) | `Revert "Merge pull request #141782 from fufexan/tlp"`            |
| [`7cd65916`](https://github.com/NixOS/nixpkgs/commit/7cd65916e94257b79ad521482ae25b32016e3896) | `texlab: 3.2.0 → 3.3.0`                                           |
| [`805b4e10`](https://github.com/NixOS/nixpkgs/commit/805b4e109b077ac14cd6b0c62213c09a627d5c3a) | `khronos: 3.5.9 -> 3.6.0`                                         |
| [`8e38ff69`](https://github.com/NixOS/nixpkgs/commit/8e38ff698e41dd8c37f98e495c7857f9777da3c4) | `notejot: 3.1.5 -> 3.2.0`                                         |
| [`9c6c5787`](https://github.com/NixOS/nixpkgs/commit/9c6c5787f6b76a081f7a46c3584c4a18fc5a8610) | `exploitdb: 2021-10-13 -> 2021-10-15`                             |
| [`400b6f42`](https://github.com/NixOS/nixpkgs/commit/400b6f42e7b4ec6a9c5306ee114d11956e2087be) | `aphleia: 0.pre+unstable=2021-08-08 -> 1.1.2+unstable=2021-10-03` |
| [`7fb3edb0`](https://github.com/NixOS/nixpkgs/commit/7fb3edb0773dd4f919a989001065fc527acc6b38) | `nixos/prometheus-rtl_433-exporter: fix systemd hardening`        |
| [`c46e938f`](https://github.com/NixOS/nixpkgs/commit/c46e938f6a245e98972d963321ea333a10f3db39) | `elpa-packages 2021-10-15`                                        |
| [`69b149a2`](https://github.com/NixOS/nixpkgs/commit/69b149a2d078e3ed2458f08e74e392d2668ef9ed) | `nongnu-packages 2021-10-15`                                      |
| [`608e9a69`](https://github.com/NixOS/nixpkgs/commit/608e9a69f67f39055332a1eeb354b53b5a168aa2) | `melpa-packages 2021-10-15`                                       |
| [`d5a4a819`](https://github.com/NixOS/nixpkgs/commit/d5a4a819f84f913ef762c8f580e0c089f7a0caf7) | `emacsPackages.rec-mode: remove manual package`                   |
| [`03bd5499`](https://github.com/NixOS/nixpkgs/commit/03bd5499af8a3d6b3b91714be7280b94ffb10903) | `python3Packages.types-requests: 2.25.10 -> 2.25.11`              |
| [`d4bb31d9`](https://github.com/NixOS/nixpkgs/commit/d4bb31d91418cc744bb7dedb65f17b3f6c931d3f) | `fzf: 0.27.2 -> 0.27.3`                                           |
| [`48b8604b`](https://github.com/NixOS/nixpkgs/commit/48b8604bbe99089e7c5f2d5c82dd1d004bcedc68) | `cimg: 2.9.8 -> 2.9.9`                                            |
| [`ddef2011`](https://github.com/NixOS/nixpkgs/commit/ddef2011adbc55b6d0e9c9b6ec3751899a466e0e) | `argtable: 3.1.5 -> 3.2.1`                                        |
| [`7a1ccd76`](https://github.com/NixOS/nixpkgs/commit/7a1ccd76de53d176dabb0060a4c97fb237aa99da) | `trezor-suite: 21.9.2 -> 21.10.2`                                 |
| [`31c9a8cf`](https://github.com/NixOS/nixpkgs/commit/31c9a8cf7b460067d66cea70b4ea4f2253cdf00c) | `maddy: fix binary path substitution in upstream systemd unit`    |
| [`2cf748bb`](https://github.com/NixOS/nixpkgs/commit/2cf748bba2a98096b760a786f15e85f942bef010) | `owncloud-client: 2.9.0 -> 2.9.1`                                 |
| [`8c9badab`](https://github.com/NixOS/nixpkgs/commit/8c9badab169d198dd08db1ef7d1558f68fb732e0) | `python3Packages.onetimepass: init at 1.0.1`                      |
| [`a1b1eec1`](https://github.com/NixOS/nixpkgs/commit/a1b1eec141fac8b733449e22e6d814d4635053fc) | `lf: 24 -> 25`                                                    |
| [`f317fb87`](https://github.com/NixOS/nixpkgs/commit/f317fb8796f1f19ee01c1b3ccbdee0c83ceb3b30) | `powertop: fix musl build`                                        |
| [`3182e542`](https://github.com/NixOS/nixpkgs/commit/3182e542730358e4629971634bda89603d9caeab) | `qogir-icon-theme: 2021-07-14 -> 2021-10-14`                      |
| [`d007e612`](https://github.com/NixOS/nixpkgs/commit/d007e612cf4d6a2e93c211a55f650f95b05ef471) | `theme-jade1: 1.13 -> 1.14`                                       |
| [`6aed355d`](https://github.com/NixOS/nixpkgs/commit/6aed355dc4809e86e603ab8f60088e9e02caa81b) | `cargo-limit: 0.0.8 -> 0.0.9`                                     |
| [`19c2d61d`](https://github.com/NixOS/nixpkgs/commit/19c2d61d880ebf5c8d50a03ad12c4ef3d1046152) | `whitesur-gtk-theme: 2021-07-27 -> 2021-09-24`                    |
| [`1864b560`](https://github.com/NixOS/nixpkgs/commit/1864b56013a9ccd11229b8f619a854981153671c) | `marwaita: 11.1 -> 11.2`                                          |
| [`8983acac`](https://github.com/NixOS/nixpkgs/commit/8983acace05a7085577a41afb290780cda07fa54) | `python3Packages.versionfinder: init at 1.1.1`                    |
| [`d9444d96`](https://github.com/NixOS/nixpkgs/commit/d9444d960aca5c856bdf2a51c327ab902d206206) | `cargo-flash: remove unused buildInputs`                          |
| [`7051b201`](https://github.com/NixOS/nixpkgs/commit/7051b2014be12ab4613232812e9b5c6d8ba8a153) | `prometheus-node-exporter: 1.1.2 -> 1.2.2`                        |
| [`b154b6f7`](https://github.com/NixOS/nixpkgs/commit/b154b6f7d89ab605a608f39e9847f20e0c6ff558) | `nixos/influxdb: Fix cross compilation for config.toml`           |