### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "06bc193d23e65790f4c37b88d33ddee3363802f6",
-        "sha256": "1cp8lc6vxyz8zcsc4db38aqxn0xvshbyhd0q4605wf68mgnjhwi4",
+        "rev": "af1ac44440c3918910cf378a4ead96a94a3f6bd6",
+        "sha256": "1kzmdx3xv8676f5vmj659l6nq5zxk049a9mv0c6f28912hpfk8ny",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/06bc193d23e65790f4c37b88d33ddee3363802f6.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/af1ac44440c3918910cf378a4ead96a94a3f6bd6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                              |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`af1ac444`](https://github.com/NixOS/nixpkgs/commit/af1ac44440c3918910cf378a4ead96a94a3f6bd6) | `jitsi: add caddy reverse proxy option`                                     |
| [`8b549804`](https://github.com/NixOS/nixpkgs/commit/8b54980441fbeb1fe24f9b746386b0a91a7a3869) | `dbeaver: 21.2.2 -> 21.2.3`                                                 |
| [`54bf57aa`](https://github.com/NixOS/nixpkgs/commit/54bf57aa1b52068862f59a5ca00b629ba50be822) | `zfs: add docs why we strip symbols manual`                                 |
| [`e5878fe2`](https://github.com/NixOS/nixpkgs/commit/e5878fe2ae40da36a4efe8ecc7046c33c9c7c81c) | `home-assistant: enable airthings tests`                                    |
| [`d49bd82a`](https://github.com/NixOS/nixpkgs/commit/d49bd82a7c1618f4c2268393a8139d1229f22daa) | `home-assistant: update component-packages`                                 |
| [`75eebdce`](https://github.com/NixOS/nixpkgs/commit/75eebdced1e5c51eef172085709a514b0d0960d1) | `python3Packages.airthings-cloud: rename module`                            |
| [`f23899c9`](https://github.com/NixOS/nixpkgs/commit/f23899c9c1f29b19d6b840c9653019dcacf31b7f) | `btop: 1.0.13 -> 1.0.16`                                                    |
| [`0066aaba`](https://github.com/NixOS/nixpkgs/commit/0066aaba321bf94ec0b72916deaacc58e5e13313) | `python3Packages.aioharmony: disable on older Python releases`              |
| [`f9f8b76e`](https://github.com/NixOS/nixpkgs/commit/f9f8b76e111d6e9fe4a0e660735d72e01a8dc191) | `python38Packages.aioharmony: 0.2.7 -> 0.2.8`                               |
| [`5f019422`](https://github.com/NixOS/nixpkgs/commit/5f0194220f2402b06f7f79bba6351895facb5acb) | `cloud-hypervisor: 18.0 -> 19.0`                                            |
| [`6a89685c`](https://github.com/NixOS/nixpkgs/commit/6a89685c00c9929374b7414b4e65f2bb08b12ec1) | `python38Packages.broadlink: 0.17.0 -> 0.18.0`                              |
| [`3c3fc76c`](https://github.com/NixOS/nixpkgs/commit/3c3fc76c13538ccc2134ec48dcda5b04a7c23cba) | `flatpak: 1.10.2 -> 1.12.2`                                                 |
| [`675c3b3d`](https://github.com/NixOS/nixpkgs/commit/675c3b3d02b1c6f9750e8221fe5322245321b29c) | `meli: alpha-0.7.1 -> alpha-0.7.2`                                          |
| [`2e00a8a3`](https://github.com/NixOS/nixpkgs/commit/2e00a8a31c7f505c4bde0b19a40d992fac4ff115) | `python3Packages.pymodbus: 2.5.3rc1 -> 2.5.3`                               |
| [`cf8610c7`](https://github.com/NixOS/nixpkgs/commit/cf8610c7b5e70008c4903b3cf5e3279c1e8e45e8) | `pythonPackages.libusb1: 1.9.3 -> 2.0.1`                                    |
| [`8eeae532`](https://github.com/NixOS/nixpkgs/commit/8eeae5320e741d55ec1b891853fa48419e3a5a26) | `tinycc: simplify specifying cc/ar`                                         |
| [`c10d30c4`](https://github.com/NixOS/nixpkgs/commit/c10d30c4347bc3d6e7e85c77582931fed9e5058d) | `randomx: 1.1.8 -> 1.1.9`                                                   |
| [`216d735f`](https://github.com/NixOS/nixpkgs/commit/216d735fad15c1a8b29bc6f2b8b763cded2aa2aa) | `rates: init at 0.5.0`                                                      |
| [`67ef64c5`](https://github.com/NixOS/nixpkgs/commit/67ef64c5cfb32382b17d02d46151bd9e504a44dd) | `llvm: bump min version for musl to 11+`                                    |
| [`826f620f`](https://github.com/NixOS/nixpkgs/commit/826f620ffe4c8202bcbf45ebe72533e5620ae567) | `vimPlugins.telescope-cheat-nvim: init at 2021-09-24`                       |
| [`f13b08e9`](https://github.com/NixOS/nixpkgs/commit/f13b08e900c283b657a5626f059ae11ef674457b) | `pdns-recursor: 4.5.4 -> 4.5.6`                                             |
| [`1ba118f4`](https://github.com/NixOS/nixpkgs/commit/1ba118f40ae227ac7545f547d0996e5000d9cd66) | `vimPlugins.comment-nvim: init at 2021-10-17`                               |
| [`222ae15d`](https://github.com/NixOS/nixpkgs/commit/222ae15d55ff4b90c7dc2ae0ef417655d8cfaf00) | `vimPlugins.better-escape-nvim: init at 2021-10-09`                         |
| [`f2ee2ca4`](https://github.com/NixOS/nixpkgs/commit/f2ee2ca4cef1507e950090f32e299ba7b9d8b135) | `vimPlugins: update`                                                        |
| [`802aa647`](https://github.com/NixOS/nixpkgs/commit/802aa64773c246c2db157f5072401a64bf9ab519) | `catcli: 0.7.3 -> 0.7.4`                                                    |
| [`8d52479b`](https://github.com/NixOS/nixpkgs/commit/8d52479bc7843cff0f291dc31da8af4f965e755d) | `nixos/libvirtd: Add configuration option for swtpm`                        |
| [`9a534569`](https://github.com/NixOS/nixpkgs/commit/9a5345698dc85bb4076116e0e9fea29898cc8946) | `tinycc: fix pkgsStatic.tinycc (musl)`                                      |
| [`9763f0b8`](https://github.com/NixOS/nixpkgs/commit/9763f0b83f95fd4e562c9298c7c321dff2ded901) | `clapper: add missing deps`                                                 |
| [`b3d58113`](https://github.com/NixOS/nixpkgs/commit/b3d5811308cbd38006332c7c33f44aa6f1848375) | `tnat64: 0.05 -> 0.06`                                                      |
| [`76842da5`](https://github.com/NixOS/nixpkgs/commit/76842da57921359a7f87c991d72462c7381f31d4) | `auto-cpufreq: 1.6.9 -> 1.7.0`                                              |
| [`c848b5d0`](https://github.com/NixOS/nixpkgs/commit/c848b5d09e3c2799283d73de84256acaecf8e443) | `python3Packages.cloudsplaining: 0.4.5 -> 0.4.6`                            |
| [`297b9572`](https://github.com/NixOS/nixpkgs/commit/297b95722d23889927126fc38403f06f1d6376fe) | `python3Packages.bytecode: 0.12.0 -> 0.13.0`                                |
| [`575394d2`](https://github.com/NixOS/nixpkgs/commit/575394d2dd8c42ce5f20ad8bbe01190439e5a94c) | `python3Packages.yeelight: 0.7.7 -> 0.7.8`                                  |
| [`663688a0`](https://github.com/NixOS/nixpkgs/commit/663688a0b34a8d08c678f7373e2670aeb4e0c3ce) | `python3Packages.fritzconnection: 1.7.0 -> 1.7.1`                           |
| [`d92c70a1`](https://github.com/NixOS/nixpkgs/commit/d92c70a199fcccd63d52111ea595b315395f06cc) | `python3Packages.plexapi: 4.7.1 -> 4.7.2`                                   |
| [`71fa2b05`](https://github.com/NixOS/nixpkgs/commit/71fa2b05f61b9caaab2bb571aa2200c72801fafb) | `rstudio: fix source revision reference`                                    |
| [`bc648809`](https://github.com/NixOS/nixpkgs/commit/bc64880909b7540ca358f2ae50fe7697d7330f40) | `python3Packages.databases: 0.5.2 -> 0.5.3`                                 |
| [`1e838a5e`](https://github.com/NixOS/nixpkgs/commit/1e838a5e5bcf655356e0d02105edaf347f28de89) | `python3Packages.deezer-python: 3.1.0 -> 3.2.0`                             |
| [`cbc562a6`](https://github.com/NixOS/nixpkgs/commit/cbc562a6aecb89cd69d431d38a7a2735546f73f5) | `python3Packages.environs: init at 9.3.4`                                   |
| [`156e94c2`](https://github.com/NixOS/nixpkgs/commit/156e94c2c5a152fa17a8a526731d8717229bd43a) | `python38Packages.bond-api: 0.1.13 -> 0.1.14`                               |
| [`1c5135dc`](https://github.com/NixOS/nixpkgs/commit/1c5135dcc373cee76e51fbb82d81f1143daa8ea4) | `python3Packages.adb-shell: 0.4.0 -> 0.4.1`                                 |
| [`3b93c7a3`](https://github.com/NixOS/nixpkgs/commit/3b93c7a39e0ae4b54a243cdacbdc83587111c0f7) | `aml: 0.2.0 -> 0.2.1`                                                       |
| [`27189a21`](https://github.com/NixOS/nixpkgs/commit/27189a21eb55b5081b1e9effbfe46546a90367f6) | `python38Packages.teslajsonpy: 1.0.1 -> 1.1.0`                              |
| [`c856904c`](https://github.com/NixOS/nixpkgs/commit/c856904cb527f2bcfd6ebeab5407b34051629978) | `python3Packages.versionfinder: use pytestCheckHook`                        |
| [`1e4ba345`](https://github.com/NixOS/nixpkgs/commit/1e4ba3455a73bf7ece6c87bfc6d6f9491e056162) | `python3Packages.pytradfri: 7.0.7 -> 7.1.0`                                 |
| [`cd2311d1`](https://github.com/NixOS/nixpkgs/commit/cd2311d1dfe9d697729c3571b49d3a5dd1395b24) | `python38Packages.django-storages: 1.12.1 -> 1.12.2`                        |
| [`d80b0c01`](https://github.com/NixOS/nixpkgs/commit/d80b0c01711f840aa703a3c923f7d941cded15b9) | `gnudatalanguage: Init at 1.0.0`                                            |
| [`eefdd9ff`](https://github.com/NixOS/nixpkgs/commit/eefdd9ffb29fad8e650ef8f063d8e4eab4e1e3c2) | `zfs: strip debug symbols`                                                  |
| [`acb119c1`](https://github.com/NixOS/nixpkgs/commit/acb119c16e9eb23ff1d8da2eea8695017c72a29c) | `python38Packages.pulsectl: 21.10.4 -> 21.10.5`                             |
| [`609928f5`](https://github.com/NixOS/nixpkgs/commit/609928f5a1599b029a12dbf748b01d23ccada5a1) | `pantheon.epiphany: rename patches`                                         |
| [`cae29344`](https://github.com/NixOS/nixpkgs/commit/cae293443bbbf07c05912c8ee1f6a6facfbde5bc) | `nixos/pantheon: prefer pantheon.evince`                                    |
| [`ce7479ef`](https://github.com/NixOS/nixpkgs/commit/ce7479ef91037dbe08540d8148cd2fdd509f4abd) | `nixos/evince: add option for specify package`                              |
| [`ac6f34a6`](https://github.com/NixOS/nixpkgs/commit/ac6f34a6698d6079a46dd1dc88e8b52d40134b8f) | `pantheon.evince: init`                                                     |
| [`471cfaf5`](https://github.com/NixOS/nixpkgs/commit/471cfaf523dfcd89ce6d91717f2fee47eb29504e) | `nixos/git: change config type`                                             |
| [`5213ac95`](https://github.com/NixOS/nixpkgs/commit/5213ac95cce079b20252afc35fdd89981b321987) | `tidy-viewer: init at 0.0.21`                                               |
| [`e1a217c1`](https://github.com/NixOS/nixpkgs/commit/e1a217c16bf599dfbc12ed61a359f609553a33a1) | `aws-c-io: 0.10.9 -> 0.10.12`                                               |
| [`067c11ef`](https://github.com/NixOS/nixpkgs/commit/067c11ef19c7d0a6ae6b47c5b169558892174b3b) | `aws-c-common: 0.6.12 -> 0.6.14`                                            |
| [`a7a6be0a`](https://github.com/NixOS/nixpkgs/commit/a7a6be0a8891257babefa8f9f61999e152740a05) | `python3Packages.asyncstdlib: 3.10.1 -> 3.10.2`                             |
| [`16ffcc8f`](https://github.com/NixOS/nixpkgs/commit/16ffcc8f547182986c39c8becc8853ea1e02c301) | `qcoro: init at 0.3.0`                                                      |
| [`4c168e46`](https://github.com/NixOS/nixpkgs/commit/4c168e46797696afa8a732a13834f62e412348e1) | `mimic: reorder attributes`                                                 |
| [`33932716`](https://github.com/NixOS/nixpkgs/commit/33932716ee75e87f980285b061fd8c41b1cebb19) | `gnome.pomodoro: 0.19.1 → 0.20.0`                                           |
| [`8f6b2808`](https://github.com/NixOS/nixpkgs/commit/8f6b280826df38eb6eabdf9c0028a93ffa24dc1d) | `maintainers: add smitop`                                                   |
| [`20785d5f`](https://github.com/NixOS/nixpkgs/commit/20785d5f4dad88138a2c9299de1d944438b4fc24) | `flashrom: Add support for Segger J-Link devices`                           |
| [`42ef9b1a`](https://github.com/NixOS/nixpkgs/commit/42ef9b1a20d330c10268440d53edd02f805991dc) | `flashrom: Use Makefile instead of Meson`                                   |
| [`3c024373`](https://github.com/NixOS/nixpkgs/commit/3c024373c16f5f677b79808ea1d5116c8caf6e9d) | `netcdf: prettify`                                                          |
| [`72a43411`](https://github.com/NixOS/nixpkgs/commit/72a43411299409918f0482d69625169ea99e1d2c) | `hdf5: consistently use *Support arguments`                                 |
| [`01cc988d`](https://github.com/NixOS/nixpkgs/commit/01cc988d9669f29855d82175a4614d90aa4bfe75) | `libressl_3_2, libressl_3_4: add patch for CVE-2021-41581`                  |
| [`0f88e9ff`](https://github.com/NixOS/nixpkgs/commit/0f88e9ff053dddbb03e4c7cc87c49648e75492f7) | `libressl: enable tests`                                                    |
| [`6a709d4e`](https://github.com/NixOS/nixpkgs/commit/6a709d4e697733adf4703f2b09f2d1813d8256d7) | `libressl: 3.2.5 -> 3.4.0, leaving libressl_3_2 available`                  |
| [`499eb1b5`](https://github.com/NixOS/nixpkgs/commit/499eb1b56a4ef24d7279920661e3ef865b0d0e37) | `hdf4: consistently use *Support arguments`                                 |
| [`9e88aadb`](https://github.com/NixOS/nixpkgs/commit/9e88aadbb4e215af141c4ea98a97c2d2a6a7cbd3) | `plplot: Support wx and xwin drivers`                                       |
| [`72d4a1f1`](https://github.com/NixOS/nixpkgs/commit/72d4a1f13d5e078b2779f2f5ebd71ffdedc82458) | `openmodelica: v1.17.0 -> v1.18.0, add balodja to openmodelica maintainers` |
| [`6dd50e47`](https://github.com/NixOS/nixpkgs/commit/6dd50e47ff42ae6028da8d211818e7b166279850) | `maintainers: add balodja`                                                  |
| [`2a041865`](https://github.com/NixOS/nixpkgs/commit/2a0418651616093e029782030d1a75d57a51294c) | `wasm-pack: mandate libressl_3_2`                                           |