### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "af1ac44440c3918910cf378a4ead96a94a3f6bd6",
-        "sha256": "1kzmdx3xv8676f5vmj659l6nq5zxk049a9mv0c6f28912hpfk8ny",
+        "rev": "a323570a264da96a0b0bcc1c9aa017794acdc752",
+        "sha256": "0xfrnc3gr2zlzg8m17j1k8c32zhakaa31djb1n9wmc4pg3zq4dg1",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/af1ac44440c3918910cf378a4ead96a94a3f6bd6.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/a323570a264da96a0b0bcc1c9aa017794acdc752.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                             |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`4949d293`](https://github.com/NixOS/nixpkgs/commit/4949d2930be526d674847b052d989ca6c1f3cec6) | `reaper: 6.29 -> 6.38 (#141914)`                                           |
| [`df01e159`](https://github.com/NixOS/nixpkgs/commit/df01e159f68771a4f293a84f73d3625a047860d9) | `rocketchat-desktop: libgpgerror -> libgpg-error`                          |
| [`7464f78b`](https://github.com/NixOS/nixpkgs/commit/7464f78b3672c34b40a2d8a7f75eaceac759a951) | `httpie: 2.5.0 -> 2.6.0`                                                   |
| [`b5301caf`](https://github.com/NixOS/nixpkgs/commit/b5301cafbcf99b986afdaa9c3463f204d5f146e8) | `hactool: add musl support && enable parallel building`                    |
| [`406d8173`](https://github.com/NixOS/nixpkgs/commit/406d8173049a2cfc95ed73b9c4324d618d8293ce) | `telegraf: 1.20.0 -> 1.20.2`                                               |
| [`d4c2aaab`](https://github.com/NixOS/nixpkgs/commit/d4c2aaab6f116a876e89c88b2bd024da0a5a6763) | `evscript: git-47f86f0 -> unstable-2021-06-16 (#127621)`                   |
| [`43d2eefe`](https://github.com/NixOS/nixpkgs/commit/43d2eefea6a42a1e77e326d36da064246b6afcb2) | `nixos/samba: Add `openFirewall` option`                                   |
| [`4937a5f3`](https://github.com/NixOS/nixpkgs/commit/4937a5f303dead15421ecc1df7c1f2fd2130b960) | `ms-toolsai.jupyter: 2021.5.745244803 -> 2021.9.1101343141 (#141772)`      |
| [`6db220af`](https://github.com/NixOS/nixpkgs/commit/6db220afca0e9b085432ce32cbcdc1b96c763c07) | `hobbits: init at 0.52.0`                                                  |
| [`d28277eb`](https://github.com/NixOS/nixpkgs/commit/d28277eb8714f60fe260490f42a5d396f186b8f3) | `zoxide: 0.7.5 -> 0.7.7`                                                   |
| [`b885f97b`](https://github.com/NixOS/nixpkgs/commit/b885f97b67bac7505287c3dda5e768ecad3211ec) | `python3Packages.teslajsonpy: 1.1.1 -> 1.1.2`                              |
| [`e753a914`](https://github.com/NixOS/nixpkgs/commit/e753a9141a9f7e610ae80978cec3ef1366b06b2d) | `ocamlPackages.ppx_deriving_yaml: init at 0.1.0 (#139635)`                 |
| [`0c227608`](https://github.com/NixOS/nixpkgs/commit/0c227608cb6069f8541e358e777a59446cf6ee2a) | `python38Packages.spacy-transformers: 1.0.6 -> 1.1.0`                      |
| [`cc280511`](https://github.com/NixOS/nixpkgs/commit/cc280511df2c895a6fa36bed9c27b961df34f8c1) | `python38Packages.soco: 0.24.0 -> 0.24.1`                                  |
| [`a1b60f08`](https://github.com/NixOS/nixpkgs/commit/a1b60f081b65d524690598ec8f93609c80f60d17) | `python38Packages.qualysclient: 0.0.4.8.1 -> 0.0.4.8.2`                    |
| [`a26d8d0b`](https://github.com/NixOS/nixpkgs/commit/a26d8d0bdceb7a19df99ac52183dc7f706294469) | `python38Packages.python-ironicclient: 4.8.0 -> 4.9.0`                     |
| [`7ee7a29c`](https://github.com/NixOS/nixpkgs/commit/7ee7a29c4acfd513c08e37ece0c183bb709b0516) | `electron_15: 15.1.2 -> 15.2.0`                                            |
| [`77c92998`](https://github.com/NixOS/nixpkgs/commit/77c929982cf56e15652e89ad125ee5af5b391324) | `ocamlPackages.ppxlib: 0.22.2 → 0.23.0`                                    |
| [`22ccc965`](https://github.com/NixOS/nixpkgs/commit/22ccc965320e7976a8a8304fc5ca9f5e465b5311) | `glitter: 1.4.4 -> 1.4.10`                                                 |
| [`134a614c`](https://github.com/NixOS/nixpkgs/commit/134a614c889cebb5f4af72e9e5149414ea5a070d) | `flexget: 3.1.139 -> 3.1.140`                                              |
| [`7fc91642`](https://github.com/NixOS/nixpkgs/commit/7fc91642e14d3236c7f2bf6563a46ae87b364ef9) | `python38Packages.mypy-boto3-s3: 1.18.63 -> 1.18.64`                       |
| [`e7933f35`](https://github.com/NixOS/nixpkgs/commit/e7933f35d4bb3d7b291d01184c9f74ae6d61346c) | `electrs: 0.9.0 -> 0.9.1`                                                  |
| [`890ca198`](https://github.com/NixOS/nixpkgs/commit/890ca19818c9a6b6409f70465b4964b0126799a5) | `electrs: add update script`                                               |
| [`aeaf4453`](https://github.com/NixOS/nixpkgs/commit/aeaf4453be3151fb4fd6a73eeac708940bed5d5f) | `electrs: use SRI hashes`                                                  |
| [`c033ff53`](https://github.com/NixOS/nixpkgs/commit/c033ff53bbf6d02fe6d5863260a752892c2f6216) | `python3Packages.hatasmota: 0.2.20 -> 0.2.21`                              |
| [`9e7a6dfe`](https://github.com/NixOS/nixpkgs/commit/9e7a6dfe375d1ae6df78ca3a17b24556e9dd5e74) | `kubescape: 1.0.120 -> 1.0.123`                                            |
| [`eca66718`](https://github.com/NixOS/nixpkgs/commit/eca667180beb2473ec85895a8679df7ffff9e7c8) | `dotnet: cleanup; point dotnet-sdk alias to 5_0; remove unsupported SDKs`  |
| [`94270774`](https://github.com/NixOS/nixpkgs/commit/94270774b1a5a4283a82ba484c55cdfde5561574) | `python3Packages.simple-rest-client: 1.1.0 -> 1.1.1`                       |
| [`b3138972`](https://github.com/NixOS/nixpkgs/commit/b3138972b6408eb574375acbe81c9e887f9b39d6) | `python3Packages.sendgrid: mark as broken`                                 |
| [`db4b0063`](https://github.com/NixOS/nixpkgs/commit/db4b00630af098be4bd1737a4d7b3c8015b522e7) | `synth: 0.5.6 -> 0.6.0`                                                    |
| [`78085fe7`](https://github.com/NixOS/nixpkgs/commit/78085fe769efd469f69bf69fc59519caac78ad25) | `python3Packages.sendgrid: 6.8.2 -> 6.8.3`                                 |
| [`07644a17`](https://github.com/NixOS/nixpkgs/commit/07644a1733ef19c9330d942ebc1f515a8c471e92) | `ekam: init at 2021-09-18 (#141064)`                                       |
| [`daa4f350`](https://github.com/NixOS/nixpkgs/commit/daa4f35079fbc4e9cd979965fa4ae9d9f0d554df) | `python3Packages.pytest-httpserver: 1.0.1 -> 1.0.2`                        |
| [`7ee41e85`](https://github.com/NixOS/nixpkgs/commit/7ee41e85e80f0f9ec9853ba841efb251d15328ad) | `steampipe: install shell completion`                                      |
| [`99e7d503`](https://github.com/NixOS/nixpkgs/commit/99e7d50315311152b6475326ffb64b2513bcf312) | `python38Packages.ecoaliface: 0.4.0 -> 0.5.0`                              |
| [`d52cc315`](https://github.com/NixOS/nixpkgs/commit/d52cc3154acc997adcaa18b12899ba6f9d4673b9) | `mattermost: 5.32.1 -> 5.37.2`                                             |
| [`bcb6ae1e`](https://github.com/NixOS/nixpkgs/commit/bcb6ae1ea691ae2e3827f466742eecc52256983d) | `python3Packages.pysma: 0.6.6 -> 0.6.7`                                    |
| [`8b535fb1`](https://github.com/NixOS/nixpkgs/commit/8b535fb1f325d9abd01d602a4d76d0aec7eeb91f) | `google_cloud_sdk: 351.0.0 -> 360.0.0 (#141773)`                           |
| [`9c46b4eb`](https://github.com/NixOS/nixpkgs/commit/9c46b4ebe179dfc2e7bea60ae34e4444772b6fb6) | `python3Packages.PyChromecast: 9.2.1 -> 9.3.0`                             |
| [`c7ba2262`](https://github.com/NixOS/nixpkgs/commit/c7ba226245131cddcafb852c0f543910739210f7) | `nextpnr: add gowin arch`                                                  |
| [`d2cef3c9`](https://github.com/NixOS/nixpkgs/commit/d2cef3c9018fa57f67d3bb35c48258ac97e572ec) | `python3Packages.velbus-aio: 2021.10.1 -> 2021.10.2`                       |
| [`77d4bc7c`](https://github.com/NixOS/nixpkgs/commit/77d4bc7c4b9bb143d935896fabd44b6658ad629a) | `python38Packages.auth0-python: 3.18.0 -> 3.19.0`                          |
| [`2375c164`](https://github.com/NixOS/nixpkgs/commit/2375c16435b70993315d4f2a694b7b2357163470) | `python38Packages.debian: 0.1.40 -> 0.1.42`                                |
| [`2d78d997`](https://github.com/NixOS/nixpkgs/commit/2d78d997720002d2516ed93a6fd1b20ce72ac745) | `nginxModules.vod: update to 1.29 and switch ffmpeg_3 to ffmpeg (#142114)` |
| [`c0512763`](https://github.com/NixOS/nixpkgs/commit/c05127634528cab7c529f51723881b4e9c25d0b0) | `python38Packages.azure-mgmt-containerservice: 16.2.0 -> 16.3.0`           |
| [`47fc40d5`](https://github.com/NixOS/nixpkgs/commit/47fc40d5ab19124339fe4ab2681be477621f1f4f) | `pythonPackages.privacyidea-ldap-proxy: 0.6.1 -> 0.6.2, switch to python3` |
| [`41879391`](https://github.com/NixOS/nixpkgs/commit/41879391a5074030fae87eb28891ce16e423609b) | `arc-theme: 20210412 -> 20211018`                                          |
| [`1ff0380e`](https://github.com/NixOS/nixpkgs/commit/1ff0380e8b30775cc071d174949f1c83f87493a1) | `calibre: 5.24.0 -> 5.29.0`                                                |
| [`d6e1fb43`](https://github.com/NixOS/nixpkgs/commit/d6e1fb43c4e61e7f3df7c72d167758d48aae4647) | `nixos/hyperv: fix evaluation of kernelParams`                             |
| [`f824d27f`](https://github.com/NixOS/nixpkgs/commit/f824d27f664c20ecb757e759e815b50cbc5c4555) | `mercurial_4: remove`                                                      |
| [`253af915`](https://github.com/NixOS/nixpkgs/commit/253af9151f69d2a39f0238eab5075e7ede1454a9) | `luaPackages: update`                                                      |
| [`744b081e`](https://github.com/NixOS/nixpkgs/commit/744b081e7572ecd4ef438aaf340a0178c77e1dd2) | `knot-dns: 3.1.2 -> 3.1.3`                                                 |
| [`15dfbb00`](https://github.com/NixOS/nixpkgs/commit/15dfbb004f07997487aae3c5ba52c6c7d493c2d6) | `freetube: 0.14.0 -> 0.15.0`                                               |
| [`3e72e18c`](https://github.com/NixOS/nixpkgs/commit/3e72e18c57a5cfbf8b5ce0adc5ead5b82e3d0f88) | `nixos/doc/manual/release_notes: add virtualisation.libvirtd changes`      |
| [`9e7b50e8`](https://github.com/NixOS/nixpkgs/commit/9e7b50e8852e542b7fd953bdb743cf30e382ff04) | `nixos/libvirtd: refactor module`                                          |
| [`bf91e284`](https://github.com/NixOS/nixpkgs/commit/bf91e2846fcd2326aed8a9d008f5b0c18232e8e6) | `python38Packages.authlib: 0.15.4 -> 0.15.5`                               |
| [`c149485e`](https://github.com/NixOS/nixpkgs/commit/c149485e8cdd8f0667bad8ae3dd6ec798beaad70) | `python38Packages.bracex: 2.1.1 -> 2.2`                                    |
| [`e6c87da4`](https://github.com/NixOS/nixpkgs/commit/e6c87da4d3cd0a158378ca9f2c8a93023d0188bb) | `nodePackages: update package set`                                         |
| [`2a9f5911`](https://github.com/NixOS/nixpkgs/commit/2a9f591159ff4f914ed739bec9df44deeefc662b) | `nodePackages.mdctl-cli: init at 1.0.62`                                   |
| [`4afaa1ab`](https://github.com/NixOS/nixpkgs/commit/4afaa1ab158ef4c4a0e66aa822c847d699149f2e) | `tidy-viewer: 0.0.21 -> 0.0.22`                                            |
| [`c0ec0aa1`](https://github.com/NixOS/nixpkgs/commit/c0ec0aa140d63431e6d1b39cf033843a4f7ac900) | `drone-cli: add 'meta.mainProgram'`                                        |
| [`ab8489cc`](https://github.com/NixOS/nixpkgs/commit/ab8489cc404462f4108c0735c7e33106917f82d9) | `Upgrade ocamlPackages.yaml and add ocamlPackages.yaml-sexp (#142089)`     |
| [`a3272852`](https://github.com/NixOS/nixpkgs/commit/a327285228e8c1265c2337aa845b2d6b5527caac) | `bront_fonts: init at 2015-06-28 (#86450)`                                 |
| [`5a44d082`](https://github.com/NixOS/nixpkgs/commit/5a44d082c8037d450a57084ad93600ae55e5a99c) | `swaycwd: 0.0.1 -> 0.0.2`                                                  |
| [`ec1fb9d1`](https://github.com/NixOS/nixpkgs/commit/ec1fb9d12a4cc2495dc27a4fe8bda01b9a516808) | `runescape: init at 2.2.9 (#139193)`                                       |
| [`7cf860aa`](https://github.com/NixOS/nixpkgs/commit/7cf860aa6a2e877bf5454597e506ed239586b4e1) | `haskellPackages: mark builds failing on hydra as broken`                  |
| [`6d0a4f9b`](https://github.com/NixOS/nixpkgs/commit/6d0a4f9b8ffa5b520cbaeccde9b6aabef39f34a8) | `nim: use newer bootstrap repository for aarch64-darwin support`           |
| [`a9f158ee`](https://github.com/NixOS/nixpkgs/commit/a9f158eebe8468b0f7131f6bbf41f81341ad473b) | `pprof: 2018-08-15 -> 2021-09-30 (#138721)`                                |
| [`51b7f3ea`](https://github.com/NixOS/nixpkgs/commit/51b7f3eac40c20b205376043811dbb2fb4e5e368) | `lesspipe: fix cross-compile (#141028)`                                    |
| [`efde6255`](https://github.com/NixOS/nixpkgs/commit/efde6255720ca9625f81d6bce9ec20dbac942e2e) | `haskellPackages.recursion-schemes: Fix profiling objects`                 |
| [`4111a140`](https://github.com/NixOS/nixpkgs/commit/4111a1409dd19d1fdb671613e8f339aebaa45b71) | `ffmpeg-normalize: 1.22.3 -> 1.22.4`                                       |
| [`d2e869a5`](https://github.com/NixOS/nixpkgs/commit/d2e869a55e9bfe46eda33c6b9821ec57f3e07bfe) | `nginxQuic: 5b0c229ba5fe -> 404de224517e`                                  |
| [`1466afbb`](https://github.com/NixOS/nixpkgs/commit/1466afbb97574a4cda3a8e5e12b0f9edda37e322) | `haskell.packages.ghc921.streaming-commons: disable tests`                 |
| [`ec8454da`](https://github.com/NixOS/nixpkgs/commit/ec8454da3328f16be052b0cdb63da6547d1981c8) | `auto-cpufreq: 1.7.0 -> 1.7.1`                                             |
| [`253bf2fc`](https://github.com/NixOS/nixpkgs/commit/253bf2fcb74564055c0a352acca4f227dd32dd2d) | `wasm-bindgen-cli: clarify license, clean up`                              |
| [`de8fa2f4`](https://github.com/NixOS/nixpkgs/commit/de8fa2f43c437f9c0291ca6f62ef148c28095d70) | `qownnotes: 21.9.2 -> 21.10.9`                                             |
| [`778679d1`](https://github.com/NixOS/nixpkgs/commit/778679d13668fe4bd516fc835593edd8dd311783) | `ytcc: 2.5.0 -> 2.5.1`                                                     |
| [`47e3de50`](https://github.com/NixOS/nixpkgs/commit/47e3de50d026d6626d5b5145c453055e508a764a) | `vimPlugins: update`                                                       |
| [`3b9d05e1`](https://github.com/NixOS/nixpkgs/commit/3b9d05e114550db6ea23befa078bd978371d863c) | `dockerTools: Fix and test #118722 path in contents`                       |
| [`c64881b6`](https://github.com/NixOS/nixpkgs/commit/c64881b6da4779115e8ee36d7e4f6443d5283e5d) | `nixopsUnstable: Add test`                                                 |
| [`d17f0576`](https://github.com/NixOS/nixpkgs/commit/d17f057641339ba2c4022e92d825b32cb30eecc4) | `python3Packages.deezer-python: 3.2.0 -> 4.0.0`                            |
| [`bd7830c2`](https://github.com/NixOS/nixpkgs/commit/bd7830c22894f529e21481a36b109076c181e551) | `bandwidth: 1.10.1 -> 1.10.4`                                              |
| [`fe0bb225`](https://github.com/NixOS/nixpkgs/commit/fe0bb225308ff2348ef1c66c1e12e64da60d0739) | `python3Packages.aiomusiccast: 0.10.0 -> 0.11.0`                           |
| [`ba44b2cc`](https://github.com/NixOS/nixpkgs/commit/ba44b2ccccc7e7ddf4dbabd411681ff7d40f1a3d) | `python3Packages.flux-led: 0.22 -> 0.24.8`                                 |
| [`3ba3855d`](https://github.com/NixOS/nixpkgs/commit/3ba3855da8001238efa0e5f76d0fbd4178f96fda) | `python3Packages.open-garage: 0.1.5 -> 0.1.6`                              |
| [`3cdaf29e`](https://github.com/NixOS/nixpkgs/commit/3cdaf29e983318c97efa65121eaffadbf32a597c) | `ptcollab: 0.4.3 -> 0.5.0`                                                 |
| [`e356eef4`](https://github.com/NixOS/nixpkgs/commit/e356eef4a827905b865713e847e8506f5d57a123) | `python3Packages.pytile: 5.2.3 -> 5.2.4`                                   |
| [`d8138c20`](https://github.com/NixOS/nixpkgs/commit/d8138c20d897bcfe2c3c07b73b3aff58938d848f) | `python3Packages.cbor2: 5.4.1 -> 5.4.2`                                    |
| [`b091b3b8`](https://github.com/NixOS/nixpkgs/commit/b091b3b853ec9ecb536a1d96e7d057e3b112b15d) | `python3Packages.teslajsonpy: 1.1.0 -> 1.1.1`                              |
| [`b678b680`](https://github.com/NixOS/nixpkgs/commit/b678b680a9f372e5b9f61615b044eb513a6f9fb0) | `hilbish: 0.5.1 -> 0.6.0`                                                  |
| [`24eb3539`](https://github.com/NixOS/nixpkgs/commit/24eb35390785e8ef8dc7adf26b6974766ae6562f) | `make-options-docs: don't sort the options XML file`                       |
| [`48c041f2`](https://github.com/NixOS/nixpkgs/commit/48c041f234e5a7bedce5b9a9d99045361e204c97) | `git-fast-export: 200213 → 210917`                                         |
| [`8930e39c`](https://github.com/NixOS/nixpkgs/commit/8930e39c11d95f99be0d260c76757b1caa499772) | `vopono: init at 0.8.6`                                                    |
| [`a8166c95`](https://github.com/NixOS/nixpkgs/commit/a8166c9574683f3392f31a1b7d40c44cfb8c9f75) | `nixos/maintainers/scripts: Avoid copy in example`                         |
| [`c2478276`](https://github.com/NixOS/nixpkgs/commit/c24782765413fceb7aad9c004a9b1ba19da9c573) | `nixosTest: Provide system.build.networkConfig`                            |
| [`d9c0e8f8`](https://github.com/NixOS/nixpkgs/commit/d9c0e8f821ccd9c726649a7e4d3a90c4ba683561) | `haskellPackages: Add dalpd as a svgcairo maintainer`                      |
| [`14c5fe8c`](https://github.com/NixOS/nixpkgs/commit/14c5fe8c1b61c957ad45d0df801c7928d9e4d134) | `nixos/subsonic: use jre8`                                                 |
| [`f9c77deb`](https://github.com/NixOS/nixpkgs/commit/f9c77deb66d9a785e129ec20d1e5e870427d37e6) | `haskellPackages.svgcairo: Update header name exposed by librsvg`          |
| [`4829bc25`](https://github.com/NixOS/nixpkgs/commit/4829bc250a9b7095786c25308c50ab052336824f) | `mkvtoolnix: 61.0.0 -> 62.0.0`                                             |
| [`8b9b630e`](https://github.com/NixOS/nixpkgs/commit/8b9b630e101b25e971cbffaf0287fa1cf2a86720) | `linux-rt_5_10: 5.10.65-rt53 -> 5.10.73-rt54`                              |
| [`664c8144`](https://github.com/NixOS/nixpkgs/commit/664c8144e4e08d0eaecb1eaeedff2b72a67036ea) | `linux: 5.4.153 -> 5.4.154`                                                |
| [`a69ff911`](https://github.com/NixOS/nixpkgs/commit/a69ff911a399148549835f27f463f9ab028a9f3f) | `linux: 5.14.12 -> 5.14.13`                                                |
| [`6b68a5ef`](https://github.com/NixOS/nixpkgs/commit/6b68a5efc1dc36c4d21de2975fc880a189a91873) | `linux: 5.10.73 -> 5.10.74`                                                |
| [`dc491697`](https://github.com/NixOS/nixpkgs/commit/dc4916976ed5bb41eb19d34d726c329d94532a81) | `linux: 4.9.286 -> 4.9.287`                                                |
| [`e2efd3de`](https://github.com/NixOS/nixpkgs/commit/e2efd3de26d644b86d87c215a248ae504da824cd) | `linux: 4.4.288 -> 4.4.289`                                                |
| [`5275780c`](https://github.com/NixOS/nixpkgs/commit/5275780c1272b08e60057379a992abd78fedee35) | `linux: 4.19.211 -> 4.19.212`                                              |
| [`62cd542b`](https://github.com/NixOS/nixpkgs/commit/62cd542b26ab5a552f8ddf96b3a48233b7d1367a) | `linux: 4.14.250 -> 4.14.251`                                              |
| [`5a1f5fea`](https://github.com/NixOS/nixpkgs/commit/5a1f5fea02d2d5fb9465b5757f283dcbe243245d) | `haskell.packages.ghc921.cereal: jailbreak (too strict bound on base)`     |
| [`6101c27a`](https://github.com/NixOS/nixpkgs/commit/6101c27a4352eb816e4a07f37b095734b596ffc4) | `release-haskell.nix: test working packages with ghc921 as well`           |
| [`76d93938`](https://github.com/NixOS/nixpkgs/commit/76d93938da7fd9c7281269cf80ebd8da063b6bf5) | `release-haskell.nix: rename all (compilers) to released (compilers)`      |
| [`7d9a6900`](https://github.com/NixOS/nixpkgs/commit/7d9a6900440c29035e930a0539cd0089e8c777f4) | `haskell.packages.ghc921.cabal-install: fix build`                         |
| [`c3bfc6a1`](https://github.com/NixOS/nixpkgs/commit/c3bfc6a1faeba744855556c4eaee3fe74e5e9dfa) | `haskell.packages.ghc921.cabal2nix: fix build`                             |
| [`4cdbb2d8`](https://github.com/NixOS/nixpkgs/commit/4cdbb2d891694870d5005f370458eeaf885f2c4f) | `nixos/switch-to-configuration: Fix ordering and indentation`              |
| [`ad09f7be`](https://github.com/NixOS/nixpkgs/commit/ad09f7be1436dfbe043c58f2c85c2da8f8445622) | `nixos/switch-to-configuration: Handle stopped sockets`                    |
| [`558158b4`](https://github.com/NixOS/nixpkgs/commit/558158b4f541628a9e28ebca9f3c2568cf2d468f) | `nixos/switch-to-configuration: Hide socket warnings`                      |
| [`047aa1a0`](https://github.com/NixOS/nixpkgs/commit/047aa1a0e9ec382ab21dea73820edd1642350215) | `nixos/switch-to-configuration: Use early return`                          |
| [`720571ee`](https://github.com/NixOS/nixpkgs/commit/720571eefab65c0c1c3efc7a5801c0eee1fe0414) | `nixos/switchTest: Also test mounts`                                       |
| [`4f870c7d`](https://github.com/NixOS/nixpkgs/commit/4f870c7d709888f935d7caf6f685c1a4930b1f6d) | `nixos/switch-to-configuration: Restart timers`                            |
| [`adc033cd`](https://github.com/NixOS/nixpkgs/commit/adc033cd5935feb85dc3477a37d2ce1c1384837b) | `nixos/switch-to-configuration: Ignore path units`                         |
| [`de128fea`](https://github.com/NixOS/nixpkgs/commit/de128feaccaf9751d7092d83f7dcc488f51a4dda) | `nixos/switch-to-configuration: Ignore slice units`                        |
| [`b515bae5`](https://github.com/NixOS/nixpkgs/commit/b515bae5cfa67e1407df1942252c98e401890c09) | `nixos/switch-to-configuration: Remove some FIXMEs`                        |
| [`cfad5e34`](https://github.com/NixOS/nixpkgs/commit/cfad5e3403de1037ee5b8fd27b814f29fbd64790) | `nixos/switch-to-configuration: Improve socket support`                    |
| [`744162ff`](https://github.com/NixOS/nixpkgs/commit/744162ffb68f03c12fa60460baaa2a6dcafacf6e) | `nixos/switch-to-configuration: Fix perlcritic warning`                    |
| [`c4d34cd1`](https://github.com/NixOS/nixpkgs/commit/c4d34cd1844d3784c69c5fdb06cad716330707e7) | `nixos/top-level: Check Syntax of switch-to-configuration`                 |
| [`f0a31f9b`](https://github.com/NixOS/nixpkgs/commit/f0a31f9b9f7a96c22907e9b508cda891861ecee7) | `nixos/switch-to-configuration: Ignore started scopes`                     |
| [`ec619ca3`](https://github.com/NixOS/nixpkgs/commit/ec619ca36951d6641a9c22201f8ae1fea28808fe) | `nixos/switch-to-configuration: Remove unused variable`                    |
| [`6312c80e`](https://github.com/NixOS/nixpkgs/commit/6312c80e069792f97d89c842a92098ed4c52a4c0) | `pijul: 1.0.0-alpha.53 → 1.0.0-alpha.54`                                   |
| [`9d79417e`](https://github.com/NixOS/nixpkgs/commit/9d79417e6e8fb1b8a7be92882e84c56eae8c9891) | `python38Packages.pycontrol4: 0.3.0 -> 0.3.1`                              |
| [`237ece08`](https://github.com/NixOS/nixpkgs/commit/237ece0800c2d8374e8a691341cc50ad5cb9944e) | `haskellPackages.compactable: not broken`                                  |
| [`d76dc812`](https://github.com/NixOS/nixpkgs/commit/d76dc8128ccb9104a8f8fde35cdf07e7dbac928f) | `pythonPackages.debugpy: 1.4.3 → 1.5.0`                                    |
| [`d3ea0893`](https://github.com/NixOS/nixpkgs/commit/d3ea0893ddb53a35ee8d78815997dfa9d7b9a980) | `graalvm11-ce: add support for aarch64-linux`                              |
| [`007ea53b`](https://github.com/NixOS/nixpkgs/commit/007ea53ba9ed1e3229593a0027fb77868bc03e53) | `graalvm: remove derivation`                                               |
| [`d4da5970`](https://github.com/NixOS/nixpkgs/commit/d4da59708c003ae40cc50d619952b3d58a267f20) | `netlify-cli: Add test`                                                    |
| [`f65b1451`](https://github.com/NixOS/nixpkgs/commit/f65b1451a0c3281205cacd4b0ec06e995f04de6f) | `netlify-cli: Switch to shrinkwrap-based package set`                      |
| [`6b09d86b`](https://github.com/NixOS/nixpkgs/commit/6b09d86b7b6a360e54dff7e1017d6b7c8e3e2c10) | `netlify-cli: Generate code with update.sh`                                |
| [`71429f81`](https://github.com/NixOS/nixpkgs/commit/71429f817db549ebc12610bd8b411df7a5077902) | `netlify-cli: Prepare shrinkwrap-based node2nix package set`               |
| [`b8aaad73`](https://github.com/NixOS/nixpkgs/commit/b8aaad732a062763602fbe6ac40b69defdcbb467) | `haskell.packages.ghc901.ormolu: fix eval`                                 |
| [`dddc15ef`](https://github.com/NixOS/nixpkgs/commit/dddc15efaadf760e3028bb0ddb171673b9a61010) | `haskellPackages: regenerate package set based on current config`          |
| [`f2deb6ea`](https://github.com/NixOS/nixpkgs/commit/f2deb6ead26ff8561666c0f0639bed78f8b12837) | `all-cabal-hashes: 2021-10-11T20:00:11Z -> 2021-10-15T10:42:20Z`           |
| [`3866d034`](https://github.com/NixOS/nixpkgs/commit/3866d03434d6f12b608290d545bc42ae8930b186) | `maintainers: add gbtb`                                                    |
| [`54294332`](https://github.com/NixOS/nixpkgs/commit/54294332aaa72c0ef7374ad7c86980947779a086) | `rocketchat-desktop: init at 3.5.7`                                        |
| [`e6c0a46a`](https://github.com/NixOS/nixpkgs/commit/e6c0a46aa8e2ee306d8f5bbd5bbc0e19a1232ee4) | `enlightenment.terminology: 1.9.0 -> 1.10.0`                               |
| [`9d6bc0f1`](https://github.com/NixOS/nixpkgs/commit/9d6bc0f1afc096c293cc08423e4a4919973298a1) | `steampipe: init at 0.8.5`                                                 |
| [`2ffaa244`](https://github.com/NixOS/nixpkgs/commit/2ffaa244b77db6ba38a732622c991ea1c0a7e4d2) | `maintainers: add hardselius`                                              |
| [`988a8e2c`](https://github.com/NixOS/nixpkgs/commit/988a8e2ca4c52696fffd71a7aca7e5b468c35177) | `python3Packages.starkbank-ecdsa: 1.1.1 -> 2.0.0`                          |
| [`e5e03737`](https://github.com/NixOS/nixpkgs/commit/e5e037378b2c4a9204da268e96378d309975cf41) | `logseq: 0.3.5 -> 0.4.2`                                                   |
| [`69c606bc`](https://github.com/NixOS/nixpkgs/commit/69c606bcc96c4480be8e996c70879e03d5866912) | `transmission: fix error when watch-dir is enabled`                        |
| [`f28de9c9`](https://github.com/NixOS/nixpkgs/commit/f28de9c95057821c72c10e3b76427103bff12ef4) | `btrbk: 0.29.1 -> 0.31.3`                                                  |
| [`744652b9`](https://github.com/NixOS/nixpkgs/commit/744652b9700e396cfa51962098385649d8bdaa34) | `kustomize-sops: 2.4.0 -> 3.0.1`                                           |
| [`18bd7df3`](https://github.com/NixOS/nixpkgs/commit/18bd7df3fa0ee89f9e073489454fe3c2d0a3135b) | `python38Packages.flufl_lock: 5.1 -> 6.0`                                  |
| [`40ef4b47`](https://github.com/NixOS/nixpkgs/commit/40ef4b47aa4e67303fc7af2f2a7f4407e45e4d46) | `python38Packages.flufl_i18n: 3.1.5 -> 3.2`                                |
| [`3abea2e4`](https://github.com/NixOS/nixpkgs/commit/3abea2e40ba0283abd20127ace389320aca53ab1) | `python38Packages.flufl_bounce: 3.0.2 -> 4.0`                              |
| [`8c0be160`](https://github.com/NixOS/nixpkgs/commit/8c0be16075ff3508c54f14221be6df43561916fa) | `adga: Add test for all packages`                                          |
| [`c84b60b2`](https://github.com/NixOS/nixpkgs/commit/c84b60b2a93b44268d4cdb440457832b729641c9) | `agda.section.md: Lay out Agda maintenance guidelines`                     |
| [`33355cc5`](https://github.com/NixOS/nixpkgs/commit/33355cc5be73c6129559ba6b8a790948171bd60b) | `agdaPackages: Build reverse dependencies on test`                         |