### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5b3ac7b07e2479df5c40320b1b218918800919ea",
-        "sha256": "055c8x8g80999iq4knfqv5lwb6939mj1j3s6vl5j6kgjl1h05nbc",
+        "rev": "79f5a81cb3855d7d2e8fe642c78d43da0d6fd9b8",
+        "sha256": "1v7zqwnjm2jsis0qvzsyd33w506z3xbsij4azjay595ig9xjpyfr",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5b3ac7b07e2479df5c40320b1b218918800919ea.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/79f5a81cb3855d7d2e8fe642c78d43da0d6fd9b8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                     |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`f69bf15a`](https://github.com/NixOS/nixpkgs/commit/f69bf15afa80cc4f2fcb765d7a561c89f20888a2) | `hqplayerd: 4.25.2-66 -> 4.26.0-67`                                |
| [`f441e6b7`](https://github.com/NixOS/nixpkgs/commit/f441e6b7f4574c85eb190b52390bbe61f355b514) | `buildRustPackage,fetchCargoTarball: accept empty hashes`          |
| [`e09fb63f`](https://github.com/NixOS/nixpkgs/commit/e09fb63ffc96b5f600c400366ffbb5db562da5c7) | `nixos/luksroot: sync the crypt-storage`                           |
| [`836e6d3e`](https://github.com/NixOS/nixpkgs/commit/836e6d3e021b56c84de76ff32f751ca4ea994079) | `buildRustPackage: remove unused arguments, minor styling changes` |
| [`ac38b7b2`](https://github.com/NixOS/nixpkgs/commit/ac38b7b21537034cac43228f4e1b61045789e116) | `uboot: add Cubieboard2 build`                                     |
| [`f11d1d91`](https://github.com/NixOS/nixpkgs/commit/f11d1d91cb734a51e1138c6a8f71a0158dd1fa59) | `SDl2_mixer: fix MIDI playback by adding timidity paths`           |