### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "360d65e180403b940afcc93d68d5329488af14eb",
-        "sha256": "00ag86iwnczig8a1vcls7g33kqcicgs9dad3hhjmqaqbzlh0bfrj",
+        "rev": "c7c01d3c63c2f2a5bc97e412c73d9949b73cb80c",
+        "sha256": "1plnpncdanlhwshkwq85qa783b0479hii6vimxhsnja0gmdyrnvq",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/360d65e180403b940afcc93d68d5329488af14eb.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/c7c01d3c63c2f2a5bc97e412c73d9949b73cb80c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                           |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`ad0ed752`](https://github.com/NixOS/nixpkgs/commit/ad0ed7527cdc986c39ba5b5f99113c77e7604238) | `snapper: 0.9.0 -> 0.9.1`                                |
| [`b90007bf`](https://github.com/NixOS/nixpkgs/commit/b90007bf494353c753bc732a75f748ce4cb519d7) | `trivy: 0.19.2 -> 0.20.2`                                |
| [`ea06d20e`](https://github.com/NixOS/nixpkgs/commit/ea06d20e142f62b1239ea8134d49063d2964500a) | `snowcat: init at 0.1.3`                                 |
| [`c8d2d591`](https://github.com/NixOS/nixpkgs/commit/c8d2d591362c10a61dadb81b7048c6aea381bf7d) | `chia: 1.2.9 -> 1.2.10`                                  |
| [`019044d2`](https://github.com/NixOS/nixpkgs/commit/019044d229455a819564a62f5d172da881d934e3) | `gitlab-runner: 14.3.2 -> 14.4.0`                        |
| [`56e6fd2b`](https://github.com/NixOS/nixpkgs/commit/56e6fd2bd1c6acb38aa07431536bea6896c22e84) | `mu: 1.6.8 -> 1.6.9`                                     |
| [`ffae3209`](https://github.com/NixOS/nixpkgs/commit/ffae3209f4b8f2ec7f7915bf00817b484fd6ac15) | `mu: 1.6.7 -> 1.6.8`                                     |
| [`9d7857c2`](https://github.com/NixOS/nixpkgs/commit/9d7857c2bbb8a1241dcb4704e65cea41b5d6c006) | `vscx/ms-vsliveshare-vsliveshare: 1.0.4836 -> 1.0.5043`  |
| [`a193eca4`](https://github.com/NixOS/nixpkgs/commit/a193eca4fb33a97ea3c6760b5df195378fd0b63e) | `python3Packages.py-synologydsm-api: 1.0.4 -> 1.0.5`     |
| [`4956a145`](https://github.com/NixOS/nixpkgs/commit/4956a145e1b6b704174a2db218e00efb6692feb4) | `strawberry: 0.9.3 -> 1.0.0`                             |
| [`4f25697a`](https://github.com/NixOS/nixpkgs/commit/4f25697acfb2cb4a512bfbd7b864dfcd0c7a00cd) | `pocket-casts: init at 0.5.0`                            |
| [`cf01d286`](https://github.com/NixOS/nixpkgs/commit/cf01d286a6036dab17968239797997b42f203b35) | `maintainers: add cleeyv to maintainers list`            |
| [`dcf4f166`](https://github.com/NixOS/nixpkgs/commit/dcf4f166692721ee796d5c0208e4652c83b22ccc) | `cloudcompare: 2.11.2 -> unstable-2021-10-14`            |
| [`05fd4054`](https://github.com/NixOS/nixpkgs/commit/05fd40540589f92c9f0ce6d8100ce2a838c44d14) | `maintainers/jitsi: add cleeyv to jitsi team`            |
| [`37762975`](https://github.com/NixOS/nixpkgs/commit/37762975b516399f20dc9973ad9571a380f6c349) | `nixos/doc: add jibri to release notes`                  |
| [`29f4cb4b`](https://github.com/NixOS/nixpkgs/commit/29f4cb4b0accf703f042bd3f5a54dd4225ae20c1) | `nixos/jibri: add nixos test`                            |
| [`917c5fae`](https://github.com/NixOS/nixpkgs/commit/917c5fae70f9d8ec43653e5a6e3ea764ce7bd2c8) | `nixos/jibri: fix & docs for enable not via meet`        |
| [`ec3c9b13`](https://github.com/NixOS/nixpkgs/commit/ec3c9b1306190c6dc16f966bde674d5e2abac897) | `jibri: downgrade to jre8_headless from default v16`     |
| [`57bd54d2`](https://github.com/NixOS/nixpkgs/commit/57bd54d28b15b871d9aac758a0f5e3686f5bce2b) | `nixos/jibri: add finalize script option`                |
| [`3473cff4`](https://github.com/NixOS/nixpkgs/commit/3473cff4b0ff09f29388558c0f54e7b44f98e2e8) | `nixos/jibri: init at 8.0-93-g51fe7a2`                   |
| [`c6c77e81`](https://github.com/NixOS/nixpkgs/commit/c6c77e819f08fdf57a56fe20330ffa28133ed6dd) | `jibri: add section to xorg conf file, for module`       |
| [`ff8ed900`](https://github.com/NixOS/nixpkgs/commit/ff8ed90033f17d754b4609edf2cc58a99cb7c73a) | `nixos/jitsi-meet: add jibri.enable`                     |
| [`ee6735ec`](https://github.com/NixOS/nixpkgs/commit/ee6735ec2270ed2c327386934abb3082148518b4) | `your-editor: styling fixup`                             |
| [`9e21b323`](https://github.com/NixOS/nixpkgs/commit/9e21b3238eb25f61b29f325dfb8775589f9a4366) | `shapely: 1.7.1 -> 1.8.0`                                |
| [`14c8bf87`](https://github.com/NixOS/nixpkgs/commit/14c8bf87430d4203b68be38e8073624e8d26fbab) | `Maintainers: Add uniquepointer`                         |
| [`fc25fa88`](https://github.com/NixOS/nixpkgs/commit/fc25fa882eda1666b96166002e8380d9139e42fb) | `your-editor: init at 1203`                              |
| [`36587c22`](https://github.com/NixOS/nixpkgs/commit/36587c22b381af8b65a71d3355537e245fb9651e) | `packet-cli: 0.5.0 -> metal-cli v0.6.0`                  |
| [`65e2e5cb`](https://github.com/NixOS/nixpkgs/commit/65e2e5cb1cd1d27aba08d72f5ab344ff1eeadf83) | `calibre: 5.29.0 -> 5.30.0`                              |
| [`d446cb11`](https://github.com/NixOS/nixpkgs/commit/d446cb11b558a150c434fb7cf57d3a9ac3a7a8e1) | `texstudio: 4.0.0 -> 4.0.2`                              |
| [`9ee66fea`](https://github.com/NixOS/nixpkgs/commit/9ee66feaadb82d660ea8e387725814a320abca8c) | `languagetool: 5.4 -> 5.5`                               |
| [`83b1c5b7`](https://github.com/NixOS/nixpkgs/commit/83b1c5b70cdafb2490edc4c51c1f58b2a53e1b48) | `htop: 3.1.0 -> 3.1.1`                                   |
| [`b7021d39`](https://github.com/NixOS/nixpkgs/commit/b7021d39baa534bb7a850e85c84dad2ff295905a) | `libnfc: Set sysconfdir to /etc`                         |
| [`569633e4`](https://github.com/NixOS/nixpkgs/commit/569633e41c3afc7b01b678bb9caf84d8716725bd) | `nixos/gnome: remove alias reference to source-sans-pro` |
| [`1717c582`](https://github.com/NixOS/nixpkgs/commit/1717c5821bc892a554c32100ff16f7c8e9ca8727) | `sn0int: 0.22.0 -> 0.23.0`                               |
| [`aa52a861`](https://github.com/NixOS/nixpkgs/commit/aa52a861a0d64d0b00701d4f0d37e470ef8fa239) | `gmid: init at 1.7.5`                                    |
| [`5c80248c`](https://github.com/NixOS/nixpkgs/commit/5c80248ce4b7e9a5ba78ed56f04a2eb31492227b) | `fastjet-contrib: 1.045 -> 1.046`                        |
| [`2b1cf544`](https://github.com/NixOS/nixpkgs/commit/2b1cf544ecd09e2c7c695ab4f287298fef74ebd2) | `python3Packages.casbin: 1.9.2 -> 1.9.3`                 |
| [`96df36bb`](https://github.com/NixOS/nixpkgs/commit/96df36bb1f08e1d6598d9f1edf4d1959a79802ee) | `python3Packages.simpleeval: 0.9.10 -> 0.9.11`           |
| [`0d94b981`](https://github.com/NixOS/nixpkgs/commit/0d94b981837880e4548f4861002b7dfa167092bb) | `python3Packages.minio: 7.1.0 -> 7.1.1`                  |
| [`451e7263`](https://github.com/NixOS/nixpkgs/commit/451e72636e6342c0803b9e3b84daa05191d98824) | `k3s: updateScript 6th fix`                              |
| [`834dec32`](https://github.com/NixOS/nixpkgs/commit/834dec327f2650c9b06d09a4f1c26d51426a3840) | `k3s: 1.21.4+k3s1 -> 1.22.2+k3s2`                        |
| [`c8b7aacc`](https://github.com/NixOS/nixpkgs/commit/c8b7aacc200cac8611be05fe525cb552a931b596) | `linkerd_edge: 21.9.3 -> 21.10.3`                        |
| [`17bda099`](https://github.com/NixOS/nixpkgs/commit/17bda099b8967488d9d28620a3c85a12bca88d51) | `linkerd: 2.10.2 -> 2.11.0`                              |
| [`53a2f192`](https://github.com/NixOS/nixpkgs/commit/53a2f192086e55114f13d757e5a9dd6f285b52f6) | `python3Packages.wakeonlan: 2.0.1 -> 2.1.0`              |
| [`12cf7636`](https://github.com/NixOS/nixpkgs/commit/12cf7636fb8bc0981e0cb99dcd544d3ce180868e) | `vulkan: 1.2.182.0 -> 1.2.189.1`                         |
| [`f48c175f`](https://github.com/NixOS/nixpkgs/commit/f48c175fb230aa3848d02de1ac4446ad737cabf9) | `doc: clarification of dependencies related attributes`  |