### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "77382d5ebf92ac0ae021d02c73357f5e11d9e3ad",
-        "sha256": "12phd3as4w5p9963bg2agxh99zhrykh3iy638yjf5dzfawsvmgf3",
+        "rev": "850251213a9df6a2f645de43e7e9b4cc6f376cf6",
+        "sha256": "1w8zdvk8p403z6pyzlfirnbkqzvls3r57pq8vn04pp378231xk01",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/77382d5ebf92ac0ae021d02c73357f5e11d9e3ad.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/850251213a9df6a2f645de43e7e9b4cc6f376cf6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                         |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
| [`5df2d4d3`](https://github.com/NixOS/nixpkgs/commit/5df2d4d34571132a193d6367ed2ececb503d11c6) | `default-crate-overrides: remove two crates that are probably irrelevant`                              |
| [`61c972d5`](https://github.com/NixOS/nixpkgs/commit/61c972d574354405f59fb2de9dc502940e3bb841) | `kumactl: init at 1.3.1 (#141858)`                                                                     |
| [`c9927750`](https://github.com/NixOS/nixpkgs/commit/c99277503eea3260ba42ae7a1229ffe09b31bd83) | `zk: init at 0.7.0 (#143020)`                                                                          |
| [`b1ee0940`](https://github.com/NixOS/nixpkgs/commit/b1ee09404ecf7999193a729220c3a08a07c9b96e) | `terranix: 2.3.0 -> 2.4.0 (#143156)`                                                                   |
| [`8336346e`](https://github.com/NixOS/nixpkgs/commit/8336346e74c7a066a9a8676f82ed47d08435ad6f) | `factorio: set pname (#143164)`                                                                        |
| [`1934d3e3`](https://github.com/NixOS/nixpkgs/commit/1934d3e325e0982de24e8367dfcad6f5b18350c2) | `python38Packages.databricks-cli: 0.16.0 -> 0.16.2`                                                    |
| [`a4daddb3`](https://github.com/NixOS/nixpkgs/commit/a4daddb3168d57d0f49e12fa21362f3fc87a05a9) | `python38Packages.tokenize-rt: 4.1.0 -> 4.2.1`                                                         |
| [`8c0c31d5`](https://github.com/NixOS/nixpkgs/commit/8c0c31d54526c316e177e6ee268f0ced7988e25d) | `firmwareLinuxNonfree: 2021-09-19 -> 20211027`                                                         |
| [`e0e815c5`](https://github.com/NixOS/nixpkgs/commit/e0e815c5ba678fe828aab782c210c78452855fde) | `python38Packages.cyclonedx-python-lib: 0.9.1 -> 0.10.2`                                               |
| [`0a6ae624`](https://github.com/NixOS/nixpkgs/commit/0a6ae624ce3bccb72979e62b311d6ceb97fd039b) | `python38Packages.colored: 1.4.2 -> 1.4.3`                                                             |
| [`83f9cf8e`](https://github.com/NixOS/nixpkgs/commit/83f9cf8eab27f6c28120d139c75cad0235c9dcd3) | `python38Packages.cocotb-bus: 0.1.1 -> 0.2.0`                                                          |
| [`ab31f0b9`](https://github.com/NixOS/nixpkgs/commit/ab31f0b9abbd0fc1dded9f805c8e2a898d2dadae) | `python38Packages.fastrlock: 0.6 -> 0.8`                                                               |
| [`3b3d4efa`](https://github.com/NixOS/nixpkgs/commit/3b3d4efa09c258c392d12a8762bce57c41bad0ea) | `python38Packages.azure-mgmt-keyvault: 9.1.0 -> 9.2.0`                                                 |
| [`87e9fb61`](https://github.com/NixOS/nixpkgs/commit/87e9fb618deece9db084324837a22de3cd9f31a0) | `python38Packages.databricks-connect: 8.1.14 -> 9.1.2`                                                 |
| [`a36a286f`](https://github.com/NixOS/nixpkgs/commit/a36a286f4863d419988a335a9cbf00bf3a938a41) | `python38Packages.azure-mgmt-containerregistry: 8.1.0 -> 8.2.0`                                        |
| [`7b095d17`](https://github.com/NixOS/nixpkgs/commit/7b095d17c066b18bcb397bc74a0c3429deb7d58c) | `python38Packages.google-cloud-automl: 2.5.0 -> 2.5.1`                                                 |
| [`5053457f`](https://github.com/NixOS/nixpkgs/commit/5053457f89b0d6b7f0d94b13e48968cc28472629) | `python38Packages.google-cloud-iam-logging: 0.2.0 -> 1.0.0`                                            |
| [`3098738c`](https://github.com/NixOS/nixpkgs/commit/3098738c9cee5918051c313eafe40451d927b75c) | `python38Packages.google-cloud-dlp: 3.2.4 -> 3.3.0`                                                    |
| [`f1bacf5b`](https://github.com/NixOS/nixpkgs/commit/f1bacf5b07370fb6a9f93e5dadee5acb3068ca6b) | `default-crate-overrides: expat-sys, glib-sys, libudev-sys, sdl2-sys, servo-fontconfig, skia-bindings` |
| [`dfc065e1`](https://github.com/NixOS/nixpkgs/commit/dfc065e1cb55de1c7278e50337276a5cbb468d92) | `python38Packages.blis: 0.7.4 -> 0.7.5`                                                                |
| [`0c82b458`](https://github.com/NixOS/nixpkgs/commit/0c82b458a25ce551d06efee24d719df08af1a9f7) | `ponysay: 3.0.3 -> unstable-2021-03-27`                                                                |
| [`4246d6ce`](https://github.com/NixOS/nixpkgs/commit/4246d6ce21d2d8d33e2d30f42b3d9d446c5dc143) | `aliases: add pkgs.system`                                                                             |
| [`1439b379`](https://github.com/NixOS/nixpkgs/commit/1439b379fffa5762528418d238826363081b4349) | `ffsend: 0.2.72 -> 0.2.74`                                                                             |
| [`0208a915`](https://github.com/NixOS/nixpkgs/commit/0208a915c8c25725523a561db593d767a5a74d3d) | `uutils-coreutils: 0.0.7 -> 0.0.8`                                                                     |
| [`a65fcb61`](https://github.com/NixOS/nixpkgs/commit/a65fcb611f8c22adca292a46ff00f053a6c37c1b) | `python38Packages.google-cloud-websecurityscanner: 1.5.0 -> 1.6.0`                                     |
| [`12f13cc9`](https://github.com/NixOS/nixpkgs/commit/12f13cc9c1096cf40353e41191066c6f4cc73b1d) | `python38Packages.plaid-python: 8.4.0 -> 8.5.0`                                                        |
| [`2a3a4a89`](https://github.com/NixOS/nixpkgs/commit/2a3a4a897b3b0f19e2fb290961c635092d1d40b0) | `python38Packages.aiounifi: 27 -> 28`                                                                  |
| [`6e4b5b87`](https://github.com/NixOS/nixpkgs/commit/6e4b5b875da305a3b039953df32e556322d6fa8e) | `cudatext: 1.146.0 → 1.148.0`                                                                          |
| [`baef45bc`](https://github.com/NixOS/nixpkgs/commit/baef45bc304c81009a6864830350b0b044492b0b) | `quickemu: 2.2.6 -> 2.2.7`                                                                             |
| [`222cbba9`](https://github.com/NixOS/nixpkgs/commit/222cbba901d1cd23cc1e34211914595fd781432d) | `python38Packages.aioftp: 0.18.1 -> 0.19.0`                                                            |
| [`da78a42d`](https://github.com/NixOS/nixpkgs/commit/da78a42db2e9960d931c6b45cae4da12de9e81a2) | `python38Packages.google-cloud-redis: 2.3.0 -> 2.4.0`                                                  |
| [`a64b27c5`](https://github.com/NixOS/nixpkgs/commit/a64b27c5f36eaad9f0268ace0ef0ac59604fe731) | `cloudcompare: Cleanup/fix comments`                                                                   |
| [`6e7c66ec`](https://github.com/NixOS/nixpkgs/commit/6e7c66ec1ed374a7f37566a54d1468d1f3761fea) | `corefonts: set pname`                                                                                 |
| [`ba77c055`](https://github.com/NixOS/nixpkgs/commit/ba77c055e53fa087674f34e045ea3b6da27cd8b1) | `python38Packages.mypy-boto3-s3: 1.19.2 -> 1.19.4`                                                     |
| [`59593b44`](https://github.com/NixOS/nixpkgs/commit/59593b443e24f8d715f9a2291df9865d63907e3a) | `android-studio-canary: 2021.2.1.1 → 2021.2.1.2`                                                       |
| [`93cfc1a9`](https://github.com/NixOS/nixpkgs/commit/93cfc1a99f2159b7d9e1e859f429355d4e844931) | `python39Packages.image-go-nord: init at 0.1.5`                                                        |
| [`e8abcc67`](https://github.com/NixOS/nixpkgs/commit/e8abcc673b0a0cd584f12ca81787f4f6beee587b) | `plexRaw: 1.24.4.5081-e362dc1ee -> 1.24.5.5173-8dcc73a59`                                              |
| [`708d430a`](https://github.com/NixOS/nixpkgs/commit/708d430aff4c50f8acd5b6ddde559ef84153bd30) | `python38Packages.trimesh: 3.9.32 -> 3.9.34`                                                           |
| [`dbee63ce`](https://github.com/NixOS/nixpkgs/commit/dbee63ce914f652a01f9eeca78b3e97372ead463) | `php74Extensions.blackfire: 1.67.0 -> 1.69.0`                                                          |
| [`fff46a0f`](https://github.com/NixOS/nixpkgs/commit/fff46a0fd9167e60873d58e07890e58f1b837892) | `zoom-us: 5.8.0.16 -> 5.8.3.145`                                                                       |
| [`066018f6`](https://github.com/NixOS/nixpkgs/commit/066018f6e1483995c4510fced3a01566370e3fdb) | `zoom-us: Update updater script for new Zoom version syntax`                                           |
| [`03fcc07a`](https://github.com/NixOS/nixpkgs/commit/03fcc07ad5b9c70b86de57f9e1848081b9735774) | `python38Packages.tablib: 3.0.0 -> 3.1.0`                                                              |
| [`a0f029c8`](https://github.com/NixOS/nixpkgs/commit/a0f029c81fe0e7471af0e95ebc29d457c96b8463) | `python38Packages.pytest-testmon: 1.2.0 -> 1.2.2`                                                      |
| [`3fa62e83`](https://github.com/NixOS/nixpkgs/commit/3fa62e832d6f2dc45148b524f146f71cf4cbe4e1) | `oh-my-zsh: 2021-10-19 -> 2021-10-27`                                                                  |
| [`3911dfc4`](https://github.com/NixOS/nixpkgs/commit/3911dfc40d4dd5f4fe905b9168313fe224865e57) | `gping: 1.2.1 -> 1.2.6 (#143124)`                                                                      |
| [`8678890e`](https://github.com/NixOS/nixpkgs/commit/8678890ef022b50cff2e7a7da607b43c380d29e0) | `python38Packages.google-cloud-iam: 2.4.0 -> 2.5.0`                                                    |
| [`d8bd500b`](https://github.com/NixOS/nixpkgs/commit/d8bd500bac2373c0f3ac8d1f329748795d7e83d2) | `dunst: patch to fix double free / avoid core dump`                                                    |
| [`1c09a32d`](https://github.com/NixOS/nixpkgs/commit/1c09a32d85120e74064e3a5873413c56357f2b79) | `tonelib-jam: 4.6.6 -> 4.7.0`                                                                          |
| [`b59803b9`](https://github.com/NixOS/nixpkgs/commit/b59803b96d4f794994e64587ccaf95e3d5225cf8) | `nodejs-16_x: 16.12.0 -> 16.13.0`                                                                      |
| [`34419738`](https://github.com/NixOS/nixpkgs/commit/34419738dde55e9a0b409852c4e6b98cc85ea1d7) | `python38Packages.APScheduler: 3.8.0 -> 3.8.1`                                                         |
| [`b3d14a4a`](https://github.com/NixOS/nixpkgs/commit/b3d14a4a527eec452f68c72622ec035b7f06ee04) | `soapyrtlsdr: enable on darwin`                                                                        |
| [`1bbbd816`](https://github.com/NixOS/nixpkgs/commit/1bbbd8166e37d57877b2551ae6e23ba3bc32e3ee) | `broot: 1.6.2 -> 1.6.6`                                                                                |
| [`14e169a0`](https://github.com/NixOS/nixpkgs/commit/14e169a0eb32623e1cc10e399703ca9828be81ac) | `python38Packages.pathy: 0.6.0 -> 0.6.1`                                                               |
| [`ec8ccb1f`](https://github.com/NixOS/nixpkgs/commit/ec8ccb1f428a192d2bcfed1eb048a40cd1060a70) | `electron: mark versions <= 11 as EOL`                                                                 |
| [`b46055e9`](https://github.com/NixOS/nixpkgs/commit/b46055e928426e825681b6583a6cd59740bd06e3) | `coqPackages.coq-elpi: 1.10 -> 1.11`                                                                   |
| [`9d969b84`](https://github.com/NixOS/nixpkgs/commit/9d969b84af3a7f3c2e205862a4990efd75bd140d) | `qbe: 2021-06-17 → 2021-10-26, fix on darwin`                                                          |
| [`16aa9f2c`](https://github.com/NixOS/nixpkgs/commit/16aa9f2ca7cbb7e8c82bbae6f8e3147c650af56e) | `mpdevil: 1.3.0 -> 1.4.0`                                                                              |
| [`0ed0c3ce`](https://github.com/NixOS/nixpkgs/commit/0ed0c3ceeb03073a8955bcb63219ed034f9c44ee) | `areca: Mark as broken`                                                                                |
| [`076a4b66`](https://github.com/NixOS/nixpkgs/commit/076a4b662cd7369d1732ad58f69d97ddf44b532d) | `swt: less arbitrary LFLAGS & cleanup`                                                                 |
| [`04fdff25`](https://github.com/NixOS/nixpkgs/commit/04fdff2517e398cfad4b951dfb8b7ffb02c81b78) | `nixos/nextcloud: drop obsolete assertion`                                                             |
| [`80577ef6`](https://github.com/NixOS/nixpkgs/commit/80577ef6c54ec6039b8f601ece8a58cd7ba1744e) | `mkgmap: 4808 -> 4810`                                                                                 |
| [`20ccd74a`](https://github.com/NixOS/nixpkgs/commit/20ccd74a3620fe0a5a9632522c8dcd46eda9dbd7) | `swt: make reproducible`                                                                               |
| [`a1ed62e5`](https://github.com/NixOS/nixpkgs/commit/a1ed62e586a5c9c09d1f39c78282395becd8e7a9) | `releaseTools.antBuild: remove`                                                                        |
| [`29fedf21`](https://github.com/NixOS/nixpkgs/commit/29fedf210f6eb7aae585946e36654e50be52e317) | `canonicalize-jars-hook: add`                                                                          |
| [`28de4f69`](https://github.com/NixOS/nixpkgs/commit/28de4f69f98f22e65e3ffac500fbd4aa5596d2c8) | `libsidplayfp: 2.2.2 -> 2.3.0`                                                                         |
| [`12908d7a`](https://github.com/NixOS/nixpkgs/commit/12908d7a486bb800f7d484ecfbdb61a2339dfe31) | `gh: 2.1.0 -> 2.2.0`                                                                                   |
| [`5f482ff3`](https://github.com/NixOS/nixpkgs/commit/5f482ff344dc5150d94c278644fe67ca4904816a) | `lagrange: 1.7.2 -> 1.7.3`                                                                             |
| [`748cc604`](https://github.com/NixOS/nixpkgs/commit/748cc6042768547201a9f6c4365cda6ed3d7dbd4) | `linux_latest-libre: 18380 -> 18413`                                                                   |
| [`55af4f5d`](https://github.com/NixOS/nixpkgs/commit/55af4f5da2bf6d1c28aca5c98ecbc31504de01ea) | `linux-rt_5_4: 5.4.143-rt64 -> 5.4.154-rt65`                                                           |
| [`67e5b8b6`](https://github.com/NixOS/nixpkgs/commit/67e5b8b626c12d575e10a82e88644bbf257eac86) | `linux: 5.4.155 -> 5.4.156`                                                                            |
| [`0719e92d`](https://github.com/NixOS/nixpkgs/commit/0719e92d1b84200d990ace44c039b3f001997c7d) | `linux: 5.14.14 -> 5.14.15`                                                                            |
| [`4bd2c087`](https://github.com/NixOS/nixpkgs/commit/4bd2c087e06419ffb266cd8f39d4a755437bf845) | `linux: 5.10.75 -> 5.10.76`                                                                            |
| [`19735ff2`](https://github.com/NixOS/nixpkgs/commit/19735ff28026c7d3bb6f7ec2b30f30d392c95eab) | `linux: 4.9.287 -> 4.9.288`                                                                            |
| [`3a69f006`](https://github.com/NixOS/nixpkgs/commit/3a69f006d9418de7ee58d16e1b32ec55dd0eca85) | `linux: 4.4.289 -> 4.4.290`                                                                            |
| [`b7efb905`](https://github.com/NixOS/nixpkgs/commit/b7efb90537964cee5fb6c350d14d89b477e58912) | `linux: 4.19.213 -> 4.19.214`                                                                          |
| [`20e62a2b`](https://github.com/NixOS/nixpkgs/commit/20e62a2b01f41a2ead0408c8c65b02edfcce95d9) | `linux: 4.14.252 -> 4.14.253`                                                                          |
| [`179292ca`](https://github.com/NixOS/nixpkgs/commit/179292cadf3d8ac222b248d1f87cc01ca5b8ae70) | `jq: add homepage`                                                                                     |
| [`92559348`](https://github.com/NixOS/nixpkgs/commit/92559348453bcc19c1e02de2ecd8396c2ead9372) | `esptool: 3.1 -> 3.2`                                                                                  |
| [`ae3a5e78`](https://github.com/NixOS/nixpkgs/commit/ae3a5e785579a5f29eb613d8df59d08759319791) | `python3Packages.aioflo: 0.4.3 -> 2021.10.0`                                                           |
| [`0b418cb6`](https://github.com/NixOS/nixpkgs/commit/0b418cb6902dd536efbc5b943d914925b457ed61) | `python3Packages.aioguardian: 1.0.8 -> 2021.10.0`                                                      |
| [`681d5e8e`](https://github.com/NixOS/nixpkgs/commit/681d5e8e267b6e8279cefff33f821f299a1e5917) | `clojure: 1.10.3.986 -> 1.10.3.998`                                                                    |
| [`0da514bc`](https://github.com/NixOS/nixpkgs/commit/0da514bc820f01846d938eec8225b435a5c15315) | `erlang: 24.1.2 -> 24.1.3`                                                                             |
| [`ce12270a`](https://github.com/NixOS/nixpkgs/commit/ce12270a07cf34e009dc94dd0e6f8f4db20f8580) | `amass: 3.14.1 -> 3.14.2`                                                                              |
| [`3813c56a`](https://github.com/NixOS/nixpkgs/commit/3813c56ac7679254ad72e01e9885a3d74e31b7df) | `eclair: 0.6.1 -> 0.6.2`                                                                               |
| [`6bc1c211`](https://github.com/NixOS/nixpkgs/commit/6bc1c211491ad8e1c970c3118b8ea65375757bea) | `nixos/tests: add google-cloud-sdk`                                                                    |
| [`8516190d`](https://github.com/NixOS/nixpkgs/commit/8516190dca71f70213fe0eed2fb16c8bbc0eb314) | `gallery-dl: 1.19.0 -> 1.19.1`                                                                         |
| [`4508ffac`](https://github.com/NixOS/nixpkgs/commit/4508ffac3ad3afe58d4c067db865edffa62fe43d) | `google-cloud-sdk: 361.0.0 -> 362.0.0`                                                                 |
| [`d561156d`](https://github.com/NixOS/nixpkgs/commit/d561156d719ff0e28084af815ef63e55cc627613) | `eww: add legendofmiracles as a maintainer`                                                            |
| [`13419138`](https://github.com/NixOS/nixpkgs/commit/134191380c7de09d3eb425ec4305ecb0c1f13e78) | `arcan.durden: 0.6.1+unstable=2021-07-11 -> 0.6.1+unstable=2021-10-15`                                 |
| [`65e85478`](https://github.com/NixOS/nixpkgs/commit/65e85478f3c87fbf17f9e119bf2b120687965009) | `arcan.arcan: 0.6.1pre1+unstable=2021-09-05 -> 0.6.1pre1+unstable=2021-10-16`                          |
| [`bb412a51`](https://github.com/NixOS/nixpkgs/commit/bb412a5125e49d93ca33edda7761ef17f6f994a3) | `gnomeExtensions: cleanup extension renames`                                                           |
| [`934ced4e`](https://github.com/NixOS/nixpkgs/commit/934ced4e81a8a83ae6744b8c30c9924315238a41) | `gnomeExtensions: set default version to 41`                                                           |
| [`050c5948`](https://github.com/NixOS/nixpkgs/commit/050c5948fcc15a71eef5e591624c1ee3196651c4) | `gnomeExtensions: auto-update and add gnome41Extensions`                                               |
| [`a41dcaad`](https://github.com/NixOS/nixpkgs/commit/a41dcaaddd58be96dde3aee4ab67963e7b96c3b0) | `k2tf: 0.5.0 -> 0.6.3`                                                                                 |
| [`99cdb84b`](https://github.com/NixOS/nixpkgs/commit/99cdb84b4b74e557f0acb984ba099752223d7f34) | `nginxQuic: 404de224517e -> 6d1488b62dc5`                                                              |
| [`0c475957`](https://github.com/NixOS/nixpkgs/commit/0c475957edde0464c16cdd2b6fb7a19402f098e5) | `eww: init at 0.2.0`                                                                                   |
| [`374ab216`](https://github.com/NixOS/nixpkgs/commit/374ab216aa4a37febf54eefe605d0cbe18cd4fe2) | `signal-desktop: 5.20.0 -> 5.21.0`                                                                     |
| [`cf87b5af`](https://github.com/NixOS/nixpkgs/commit/cf87b5af96f22064b61656ea1e94158dcf260812) | `Better wording on a small comment`                                                                    |
| [`f53cd2e3`](https://github.com/NixOS/nixpkgs/commit/f53cd2e3ec0712503f598cb8ff8466d6358079ff) | `"treewide" moving Arcan packages to directories`                                                      |
| [`0066510a`](https://github.com/NixOS/nixpkgs/commit/0066510a57ca5b2390ba871ec9da4fa7c68abe9c) | `tts: 0.3.1 -> 0.4.1`                                                                                  |
| [`a96c0103`](https://github.com/NixOS/nixpkgs/commit/a96c0103914e93f23e87361a8c4b3f4b8c4d82a5) | `gnomeExtensions.easyScreenCast: unstable-2020-11-25 -> 1.4.0`                                         |
| [`219130a2`](https://github.com/NixOS/nixpkgs/commit/219130a2f03c0f18a3f9976c319cc260eaf126c0) | `sbcl: compile with linkable runtime`                                                                  |
| [`1d948428`](https://github.com/NixOS/nixpkgs/commit/1d948428c893ded64e92502a394abc59be130a91) | `nixos/mastodon: fix send e-mail notifications`                                                        |
| [`ea8f2f93`](https://github.com/NixOS/nixpkgs/commit/ea8f2f937c221428e184b830d7d61d9e9524e29e) | `treewide: allow eval with no-url-literals`                                                            |
| [`0017d42f`](https://github.com/NixOS/nixpkgs/commit/0017d42f1edeb6b58ea4d0448664156300bc7ebd) | `libstdc++5: Fix build failure on missing libc-ldflags-before`                                         |
| [`d1f8e247`](https://github.com/NixOS/nixpkgs/commit/d1f8e247d101d3c077de87baa676eb748a8fe55f) | `elmPakages.*: semi-automatic update`                                                                  |
| [`e1e15974`](https://github.com/NixOS/nixpkgs/commit/e1e15974f8123dcfa2272ba594c5638dc73c787c) | `nextcloud20: drop`                                                                                    |
| [`3a3c1e94`](https://github.com/NixOS/nixpkgs/commit/3a3c1e94fba46e9da61f42721dec989b15afe84c) | `zigbee2mqtt: remove toplevel system attr`                                                             |
| [`0b918edc`](https://github.com/NixOS/nixpkgs/commit/0b918edc99a66cbd0a4db819ff2e730dc58847a8) | `adguardhome: remove toplevel system attr`                                                             |
| [`1f6d7365`](https://github.com/NixOS/nixpkgs/commit/1f6d7365a9789d9cefb7871b4d998e71a09e0b9d) | `build2: enable on all platforms`                                                                      |
| [`1c6b48a4`](https://github.com/NixOS/nixpkgs/commit/1c6b48a4234869f4db35d96240b834e5e9137c01) | `build2: 0.13.0 -> 0.14.0`                                                                             |
| [`a76673ee`](https://github.com/NixOS/nixpkgs/commit/a76673ee06e1026cd7f1f48182b8a5a140f60ee3) | `zim: 0.73.5 -> 0.74.2`                                                                                |
| [`b7d06138`](https://github.com/NixOS/nixpkgs/commit/b7d06138c88bc19dbf1e41a4b3ec9450ca950d5a) | `firefox-bin: simplify locale selection`                                                               |
| [`5739ba1a`](https://github.com/NixOS/nixpkgs/commit/5739ba1a27b9a53bdc92ae7e769b1f052440db4b) | `build2.bootstrap: 0.13.0 -> 0.14.0`                                                                   |
| [`aed6bb33`](https://github.com/NixOS/nixpkgs/commit/aed6bb336ecf85d85acfd79f21054eb4ec288de7) | `build-support/docker: remove toplevel system attr`                                                    |
| [`4423c7ec`](https://github.com/NixOS/nixpkgs/commit/4423c7ecbcf0cdb3810c09df8a962ea7197edff9) | `crun: remove toplevel system attr`                                                                    |
| [`2bbc2eae`](https://github.com/NixOS/nixpkgs/commit/2bbc2eaed34175505f8c864bd7b10579a156bce9) | `bookstack: remove toplevel system attr`                                                               |
| [`54aa92a5`](https://github.com/NixOS/nixpkgs/commit/54aa92a5425bb34e6765b8f57acf13dd6652e48b) | `fx_cast: remove toplevel system attr`                                                                 |
| [`2be1c9ea`](https://github.com/NixOS/nixpkgs/commit/2be1c9eae1fa33cc1e4c8c6b9ccee44a8d3f474d) | `navidrome: remove toplevel system attr`                                                               |
| [`f8578236`](https://github.com/NixOS/nixpkgs/commit/f85782360ceeb21ab578974fc42290fe0858eab8) | `nsq: 0.3.5 -> 1.2.1`                                                                                  |
| [`0b15a999`](https://github.com/NixOS/nixpkgs/commit/0b15a9997ce231bc5a68dcf58e407daacac50a83) | `github-runner: add aarch64-linux to platforms`                                                        |
| [`6a144364`](https://github.com/NixOS/nixpkgs/commit/6a144364cc1fa4f9c37f9cea1c13e355f9dc71b6) | `firefox-bin: fix locale selection`                                                                    |