### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "850251213a9df6a2f645de43e7e9b4cc6f376cf6",
-        "sha256": "1w8zdvk8p403z6pyzlfirnbkqzvls3r57pq8vn04pp378231xk01",
+        "rev": "7f3494b3436bbedf8bb9cfe157871e8c1d398225",
+        "sha256": "1yi59ijmk065p49agammdyl34cjkc9a35hhg5ssi49d679rann1m",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/850251213a9df6a2f645de43e7e9b4cc6f376cf6.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/7f3494b3436bbedf8bb9cfe157871e8c1d398225.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                               |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`9ce555e0`](https://github.com/NixOS/nixpkgs/commit/9ce555e0afaefa5715c6d89067c81b7418e91640) | `newsboat: 2.24 -> 2.25`                                     |
| [`4effa256`](https://github.com/NixOS/nixpkgs/commit/4effa2569a594e1c3b53bdbdc0fae8c3307ba15a) | `python38Packages.phonopy: 2.11.0 -> 2.12.0`                 |
| [`252b4731`](https://github.com/NixOS/nixpkgs/commit/252b4731457f1db3e94fa3e1d523b998bd794169) | `terraform-ls: 0.22.0 -> 0.23.0`                             |
| [`a97c0846`](https://github.com/NixOS/nixpkgs/commit/a97c084633c004fdc9067a1ae90f16071da2043b) | `lnav: 0.10.0 -> 0.10.1`                                     |
| [`40bad15b`](https://github.com/NixOS/nixpkgs/commit/40bad15b21f81b607f1ce54ef90d244e00b5c237) | `ocamlPackages.dune-site: init 2.9.1`                        |
| [`c535db45`](https://github.com/NixOS/nixpkgs/commit/c535db45ceb6d9aaecd5d260127ecf8335000378) | `ocamlPackages.cppo: 1.6.7 → 1.6.8`                          |
| [`b77b4521`](https://github.com/NixOS/nixpkgs/commit/b77b452186ea1b3918084083c2107d9f7af0ffdc) | `electron_13: 13.6.0 -> 13.6.1`                              |
| [`631baa9a`](https://github.com/NixOS/nixpkgs/commit/631baa9ab92f198b0899bcee92a5fb1656c85264) | `delta: 0.8.3 -> 0.9.1`                                      |
| [`46905d95`](https://github.com/NixOS/nixpkgs/commit/46905d953d9b4c66fc5f76836d0a344c3e37d828) | `flexget: 3.1.140 -> 3.1.148`                                |
| [`99494ca9`](https://github.com/NixOS/nixpkgs/commit/99494ca98d782e7653796534288181d50252872f) | `tdlib: 1.7.0 -> 1.7.8 (#143176)`                            |
| [`44ffcb83`](https://github.com/NixOS/nixpkgs/commit/44ffcb836239ef0e608728223166740b632ce994) | `discourse: 2.7.8 -> 2.7.9`                                  |
| [`ba550367`](https://github.com/NixOS/nixpkgs/commit/ba55036722ed94745f5decde2df7e00a14be4b56) | `angle-grinder: 0.17.0 -> 0.18.0`                            |
| [`8ff3aad7`](https://github.com/NixOS/nixpkgs/commit/8ff3aad7fe0016c919670524a91638ea7f35830b) | `xscreensaver: 6.01 -> 6.02`                                 |
| [`14d3b5fd`](https://github.com/NixOS/nixpkgs/commit/14d3b5fd01cfc73b934ac1bf1d6cbfecf21818f6) | `img2pdf: 0.4.2 -> 0.4.3`                                    |
| [`6366a136`](https://github.com/NixOS/nixpkgs/commit/6366a136e3daa8b61e56cf7c53e07b4c97a64eba) | `yubikey-manager-qt: 1.2.3 -> 1.2.4`                         |
| [`ec1463be`](https://github.com/NixOS/nixpkgs/commit/ec1463beb6e44110eaf101fcc2ab8f718bb359b7) | `yq-go: 4.13.2 -> 4.13.5`                                    |
| [`572dcd44`](https://github.com/NixOS/nixpkgs/commit/572dcd44a11c5c597495db1102ce7110ca266eff) | `zoxide: 0.7.7 -> 0.7.8`                                     |
| [`c5d74126`](https://github.com/NixOS/nixpkgs/commit/c5d741263099674cbba74e496e201afbb1ec29ed) | `ansible-lint: 5.2.0 -> 5.2.1`                               |
| [`8f6f42bd`](https://github.com/NixOS/nixpkgs/commit/8f6f42bd36ff0167d8041c1c047440627dd2d171) | `python38Packages.flask-paginate: 0.8.1 -> 2021.10.26`       |
| [`4080dff4`](https://github.com/NixOS/nixpkgs/commit/4080dff4f6bcf0a748d21a6b6d53c866e6eeec15) | `gcc8: 8.4.0 -> 8.5.0`                                       |
| [`d5ea3f60`](https://github.com/NixOS/nixpkgs/commit/d5ea3f60b1fa67d72c41dfa93c506d2e4e855c20) | `pipreqs: 0.4.10 -> 0.4.11`                                  |
| [`ca4560cb`](https://github.com/NixOS/nixpkgs/commit/ca4560cbc01f0998e0191ebea390a0747330e6c6) | `github-desktop: 2.9.3 -> 2.9.4`                             |
| [`0ff42762`](https://github.com/NixOS/nixpkgs/commit/0ff42762ebd46ee186c832c17a6df696b3675d94) | `python3Packages.aiowatttime: 0.1.1 -> 2021.10.0`            |
| [`9c73c4d0`](https://github.com/NixOS/nixpkgs/commit/9c73c4d06f7d9b871981c5ee62c2f3c0e84aa006) | `python3Packages.aioridwell: 0.2.0 -> 2021.10.0`             |
| [`99c0bf4b`](https://github.com/NixOS/nixpkgs/commit/99c0bf4bf08f098480160eea78d11b2e730982ff) | `python3Packages.aionotion: 3.0.2 -> 2021.10.0`              |
| [`04af8917`](https://github.com/NixOS/nixpkgs/commit/04af89173e47902e853e42d616bbe5c8b70f2941) | `pantheon.elementary-camera: 6.0.0 -> 6.0.1`                 |
| [`2ce34395`](https://github.com/NixOS/nixpkgs/commit/2ce343951d90cfb8dc443b6f46dec73ee01a4ac8) | `pantheon.wingpanel-applications-menu: 2.9.0 -> 2.9.1`       |
| [`acb17ade`](https://github.com/NixOS/nixpkgs/commit/acb17adef6be1b1779dbbd2a6c9e9fda12698cbc) | `pantheon.elementary-photos: 2.7.2 -> 2.7.3`                 |
| [`4ce576b3`](https://github.com/NixOS/nixpkgs/commit/4ce576b36ff9b177a4ec0db38201663eaf9a5643) | `pantheon.wingpanel-indicator-notifications: 6.0.1 -> 6.0.2` |
| [`36cc1ae2`](https://github.com/NixOS/nixpkgs/commit/36cc1ae2ab7ad9257bf1499b58195fa16489af1d) | `pantheon.elementary-calendar: 6.0.2 -> 6.0.3`               |
| [`c0c3b61e`](https://github.com/NixOS/nixpkgs/commit/c0c3b61e2e210546cb0bcc0953b3710476b46f5c) | `pantheon.appcenter: 3.8.0 -> 3.8.1`                         |
| [`2fcee1e3`](https://github.com/NixOS/nixpkgs/commit/2fcee1e35c09b96ec6d39407ee338103d836ede4) | `pantheon.elementary-calculator: 1.7.0 -> 1.7.1`             |
| [`20a9ac8d`](https://github.com/NixOS/nixpkgs/commit/20a9ac8d35bb9a3b618df441bcc7c6f09353b040) | `pantheon.epiphany: update patches`                          |
| [`a57a7c03`](https://github.com/NixOS/nixpkgs/commit/a57a7c035f5152019541310883ffbaae480be62b) | `tootle: pin vala version to 0.52`                           |
| [`6a0e026b`](https://github.com/NixOS/nixpkgs/commit/6a0e026b01e9ce386039d8d7439743adac5dc6bf) | `pantheon.wingpanel-indicator-network: 2.3.0 -> 2.3.1`       |
| [`28e96b43`](https://github.com/NixOS/nixpkgs/commit/28e96b4352bbdb4db06508aa224d5b2249eaffd1) | `python3Packages.pyjet: 1.6.0 -> 1.8.2`                      |
| [`6ef3339c`](https://github.com/NixOS/nixpkgs/commit/6ef3339cfb2391355c24672cad1799959497f8c7) | `pantheon.granite: 6.1.1 -> 6.1.2`                           |
| [`4780b6df`](https://github.com/NixOS/nixpkgs/commit/4780b6df1a58ae0e210efd76de58f28309a07030) | `pantheon.elementary-settings-daemon: 1.0.0 -> 1.1.0`        |
| [`e26214dd`](https://github.com/NixOS/nixpkgs/commit/e26214dd6ced84c5dbcc02353d616d49c815d3a3) | `xdg-desktop-portal-pantheon: init at 1.0.0`                 |
| [`c2ae15cc`](https://github.com/NixOS/nixpkgs/commit/c2ae15cc31ab2bdb2315f8d1d5f966f544fc376c) | `touchegg: 2.0.11 -> 2.0.12`                                 |