### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3d29e432018ea74bb54eea4b6d475f74dfb00568",
-        "sha256": "1b292wzrz0radr752gizixz3zgddwd1jf1420p5cv9bcxk5jxzbn",
+        "rev": "fc1535cfb9cb82c5ddd9edec76c81028195b9b6c",
+        "sha256": "1al2rqh564zfalf7mw75p80il4ps57qvism9ihjid2v6m1zl53wb",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/3d29e432018ea74bb54eea4b6d475f74dfb00568.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/fc1535cfb9cb82c5ddd9edec76c81028195b9b6c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                            |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`604168a4`](https://github.com/NixOS/nixpkgs/commit/604168a4b23ae41e4dd43e73776efcf3d9fce2f3) | `python38Packages.scikit-hep-testdata: 0.4.9 -> 0.4.10`                   |
| [`e0ee3a83`](https://github.com/NixOS/nixpkgs/commit/e0ee3a830ca9a1b1d8419ac92615d4bd530c3779) | `duplicity: Update homepage URL`                                          |
| [`23308044`](https://github.com/NixOS/nixpkgs/commit/23308044efafcc44f62d6fbc3251b84b56ac4b6a) | `utox: 0.17.0 -> 0.18.1`                                                  |
| [`bf6e22d4`](https://github.com/NixOS/nixpkgs/commit/bf6e22d4270077f1ef46ef341d21952b68dffd4b) | `cliphist: 0.1.0 -> 0.3.0`                                                |
| [`33e63f75`](https://github.com/NixOS/nixpkgs/commit/33e63f7542b2a311c65438b4e5fe81dd7255da7f) | `cilium-cli: 0.9.0 -> 0.9.2`                                              |
| [`de4d04d2`](https://github.com/NixOS/nixpkgs/commit/de4d04d24e713a17841217120bb0103cb216396e) | `cheat: 4.2.2 -> 4.2.3`                                                   |
| [`00334d35`](https://github.com/NixOS/nixpkgs/commit/00334d352f2948ab5bcb28ba674d9c55e1b5f2ec) | `Revert "makeRustPlatform: allow to easily override stdenv"`              |
| [`f9b615c9`](https://github.com/NixOS/nixpkgs/commit/f9b615c9ffa9141e3659e166c200fe57cfb23bdd) | `qbs: 1.20.0 -> 1.20.1`                                                   |
| [`aa83863a`](https://github.com/NixOS/nixpkgs/commit/aa83863ad0c084a9d5a59b47c6230d42075d92dd) | `chamber: 2.10.3 -> 2.10.6`                                               |
| [`de7f7a80`](https://github.com/NixOS/nixpkgs/commit/de7f7a80979c0486313e61f902708f3df4463d5a) | `cargo-feature: 0.5.3 -> 0.5.5`                                           |
| [`ebaf71bc`](https://github.com/NixOS/nixpkgs/commit/ebaf71bc57e693252a2fedb306d8b96d17b28cc8) | `bupstash: 0.10.2 -> 0.10.3`                                              |
| [`0342aee9`](https://github.com/NixOS/nixpkgs/commit/0342aee96979e8109d7647a41b1c05768e4c801d) | `sane-airscan: 0.99.26 -> 0.99.27`                                        |
| [`02facd2d`](https://github.com/NixOS/nixpkgs/commit/02facd2d449a58968969323622cb4d12c55df132) | `btop: 1.0.18 -> 1.0.20`                                                  |
| [`d95f44ad`](https://github.com/NixOS/nixpkgs/commit/d95f44adf25831ef36df2fcdb0e46334df8d6755) | `gmailctl: install completion files`                                      |
| [`6f8af609`](https://github.com/NixOS/nixpkgs/commit/6f8af6097c1c990d8671a788b504f44f43139001) | `rakudo: 2021.07 -> 2021.10`                                              |
| [`8f4e3a05`](https://github.com/NixOS/nixpkgs/commit/8f4e3a052d461b5f874be87ca5da1da87f52f444) | `nqp: 2021.07 -> 2021.10`                                                 |
| [`c2b56a27`](https://github.com/NixOS/nixpkgs/commit/c2b56a270eca45901eabf07250dd9998102ef6ff) | `moarvm: 2021.07 -> 2021.10`                                              |
| [`05ae303d`](https://github.com/NixOS/nixpkgs/commit/05ae303d634b19dcc7b3e71727bfefe5c3082bf3) | `zef: 0.11.11 -> 0.13.0`                                                  |
| [`ecacdde7`](https://github.com/NixOS/nixpkgs/commit/ecacdde7cfcb837a444a98076878ae17f8c1a4e4) | `s3backer: 1.6.2 -> 1.6.3`                                                |
| [`736dcd89`](https://github.com/NixOS/nixpkgs/commit/736dcd89558671cfaad59620dc1369d4194343a3) | `zfs-kernel: fix strip in cross-compilation`                              |
| [`9a6f220a`](https://github.com/NixOS/nixpkgs/commit/9a6f220ab98473eee898c62c555ddddedc7edc81) | `inkscape: 1.0 → 1.1.1`                                                   |
| [`760160e6`](https://github.com/NixOS/nixpkgs/commit/760160e64d498b0ae8d59ec2b3ddb8c9b9fd9e90) | `bcal: 2.2 -> 2.3`                                                        |
| [`74df451f`](https://github.com/NixOS/nixpkgs/commit/74df451f60b9a071351166f811e419974a053c12) | `bazel-remote: 2.1.3 -> 2.2.0`                                            |
| [`7807e82c`](https://github.com/NixOS/nixpkgs/commit/7807e82c0acdc63594acd836248bea151a3772f9) | `remind: 03.03.07 -> 03.03.09`                                            |
| [`5f33ec48`](https://github.com/NixOS/nixpkgs/commit/5f33ec4892064a0dcdbb431cab0c2848f8012db2) | `bazel-buildtools: 4.2.0 -> 4.2.3`                                        |
| [`333aa4b8`](https://github.com/NixOS/nixpkgs/commit/333aa4b889c1acba44a1dd35815b95df2f2b199a) | `bacon: 1.1.8 -> 1.2.2`                                                   |
| [`b2018e82`](https://github.com/NixOS/nixpkgs/commit/b2018e825913082c702e01af7a0aabf4eac3e944) | `b3sum: 1.0.0 -> 1.1.0`                                                   |
| [`85884092`](https://github.com/NixOS/nixpkgs/commit/858840921739513f9d1ca64fbe4800b46c46689e) | `azure-functions-core-tools: 3.0.3734 -> 3.0.3785`                        |
| [`11966c8f`](https://github.com/NixOS/nixpkgs/commit/11966c8ff4bfe1605ee3655198d19d336a0b28ab) | `aws-c-http: 0.6.7 -> 0.6.8`                                              |
| [`28f11198`](https://github.com/NixOS/nixpkgs/commit/28f111989d54f0bf5b8ea145ad2b8aac6b3003d7) | `python38Packages.scikit-hep-testdata: 0.4.9 -> 0.4.10`                   |
| [`af2ac848`](https://github.com/NixOS/nixpkgs/commit/af2ac84863bb15c26c7c3d5c2fd08ac492de1cbe) | `pantheon.elementary-default-settings: add dockitem for elementary-tasks` |
| [`6629b16e`](https://github.com/NixOS/nixpkgs/commit/6629b16e78f101f67260c28192491816bcd8d0e9) | `nixos/pantheon: install elementary-tasks by default`                     |
| [`e9de3408`](https://github.com/NixOS/nixpkgs/commit/e9de3408273b4e9a8b9f40ce432d2efb4aef7a50) | `xdg-desktop-portal-pantheon: 1.0.0 -> 1.0.1`                             |
| [`de1e932a`](https://github.com/NixOS/nixpkgs/commit/de1e932add1be6600251ba43a564ed3ba48d9048) | `bisq-desktop: 1.7.4 -> 1.7.5`                                            |
| [`83fdaff9`](https://github.com/NixOS/nixpkgs/commit/83fdaff9f71276d8e0b93263e2e05e1079cbabdb) | `sharedown: Improve expression formatting`                                |
| [`049264c3`](https://github.com/NixOS/nixpkgs/commit/049264c39b153a59c0bc01ed33e788ad0a3cf393) | `sdrpp: enable on darwin`                                                 |
| [`0f2c51b8`](https://github.com/NixOS/nixpkgs/commit/0f2c51b8315030aeaf026878256436b0666ade4d) | `rssguard: 4.0.2 -> 4.0.4`                                                |
| [`8b4d8118`](https://github.com/NixOS/nixpkgs/commit/8b4d811830054152b42b1fbbcecbfd2996f43116) | `s5cmd: 1.3.0 -> 1.4.0`                                                   |
| [`399b3fe6`](https://github.com/NixOS/nixpkgs/commit/399b3fe6a632f886c460e3bff138c7a4493fcd42) | `roswell: 21.06.14.110 -> 21.10.14.111`                                   |
| [`39c15074`](https://github.com/NixOS/nixpkgs/commit/39c150745781b3428b9954fd4fa127c8b8f2a988) | `sinit: 1.0 -> 1.1`                                                       |
| [`bd4c6152`](https://github.com/NixOS/nixpkgs/commit/bd4c61523afae303d70f3fbc3e3f5cb820fb082b) | `snd: fix build on darwin`                                                |
| [`2cdc3bd3`](https://github.com/NixOS/nixpkgs/commit/2cdc3bd3cc3a220cf1e2a7183db17b2bd12e410b) | `snd: 21.7 -> 21.8`                                                       |
| [`1b52d9ef`](https://github.com/NixOS/nixpkgs/commit/1b52d9efc1721bd7bd7a34fa7011401d35472087) | `seaweedfs: 2.63 -> 2.71`                                                 |
| [`d61921d8`](https://github.com/NixOS/nixpkgs/commit/d61921d8a9656f7a85b91349a175c26b6a67f109) | `sfeed: 0.9.21 -> 1.0`                                                    |
| [`78a5bd5b`](https://github.com/NixOS/nixpkgs/commit/78a5bd5be92833170ba2094ad29da3110e6c818b) | `songrec: 0.2.0 -> 0.2.1`                                                 |
| [`9b8d14c7`](https://github.com/NixOS/nixpkgs/commit/9b8d14c700f62d09f077cebf277b8db8e893031b) | `spicetify-cli: 2.2.6 -> 2.7.1`                                           |
| [`4c62d1e6`](https://github.com/NixOS/nixpkgs/commit/4c62d1e6bdde0d8ed49bc9b8ada429c4b9c02f0f) | `subfinder: 2.4.8 -> 2.4.9`                                               |
| [`3b1fcb16`](https://github.com/NixOS/nixpkgs/commit/3b1fcb16e62cb0551057c9efd0e641b1e36330a8) | `swagger-codegen3: 3.0.25 -> 3.0.29`                                      |
| [`3f76ca8d`](https://github.com/NixOS/nixpkgs/commit/3f76ca8d0ddcc97c38f46e53c4936bb02a4ad170) | `simdjson: 1.0.0 -> 1.0.1`                                                |
| [`f6bc7596`](https://github.com/NixOS/nixpkgs/commit/f6bc759658731e550e795ecc2b7800229af5a736) | `staruml: 4.0.1 -> 4.1.6`                                                 |
| [`9a2d2c85`](https://github.com/NixOS/nixpkgs/commit/9a2d2c85ef099efc03791553404dea5bc5ad6cc0) | `seafile-client: 8.0.3 -> 8.0.4`                                          |
| [`308cafef`](https://github.com/NixOS/nixpkgs/commit/308cafefd1d927136987fd97067124dc1ea84ac7) | `symfony-cli: 4.26.3 -> 4.26.8`                                           |
| [`26629f59`](https://github.com/NixOS/nixpkgs/commit/26629f59a6b69a6ce13bfe65a7ac875456a71f24) | `python38Packages.launchpadlib: 1.10.14 -> 1.10.15.1`                     |
| [`c1c2f0d9`](https://github.com/NixOS/nixpkgs/commit/c1c2f0d950743275c81bb11434046d7fafb37d49) | `squid: 4.16 -> 4.17`                                                     |
| [`9a29e6ea`](https://github.com/NixOS/nixpkgs/commit/9a29e6eaabf87b6a38c10172d3484e1e0c2313d4) | `snapraid: 11.5 -> 11.6`                                                  |
| [`d2ffd758`](https://github.com/NixOS/nixpkgs/commit/d2ffd758bd3f0fff97ab12b32ad6c062597f233f) | `terracognita: 0.7.3 -> 0.7.4`                                            |
| [`44452f0e`](https://github.com/NixOS/nixpkgs/commit/44452f0ebb3b9f60dcdd86e986aa18419ceac9f1) | `tixati: 2.84 -> 2.85`                                                    |
| [`d9ebe400`](https://github.com/NixOS/nixpkgs/commit/d9ebe400f8091efa7fa3be4430429fef5dd002cc) | `postgresqlPackages.timescaledb: add comment why refs/tags is used`       |
| [`3f60aa06`](https://github.com/NixOS/nixpkgs/commit/3f60aa06f53743ad8fd06a81715e9f0a3682f366) | `ugrep: 3.3.7 -> 3.3.8`                                                   |
| [`bb2053b2`](https://github.com/NixOS/nixpkgs/commit/bb2053b215ab19682fd905f552d4c34f4573b1b0) | `tut: 0.0.33 -> 0.0.36`                                                   |
| [`e478b531`](https://github.com/NixOS/nixpkgs/commit/e478b5310b012f4587a141d7127c9620b92d5175) | `tendermint: 0.34.13 -> 0.34.14`                                          |
| [`e016ac39`](https://github.com/NixOS/nixpkgs/commit/e016ac393c2159b85043fc11dbda84760fc0a630) | `timezonemap: 0.4.5 -> 0.4.5.1`                                           |
| [`f785bbf4`](https://github.com/NixOS/nixpkgs/commit/f785bbf4bf94a61424a6996862c9ebf6cc27ca03) | `tintin: 2.02.11 -> 2.02.12`                                              |
| [`2f8c98ac`](https://github.com/NixOS/nixpkgs/commit/2f8c98ace36908388f1cad492d6427e7dd20af17) | `tpm2-pkcs11: 1.5.0 -> 1.7.0`                                             |
| [`e0fce695`](https://github.com/NixOS/nixpkgs/commit/e0fce695eafd9bbf4014f1ad8c9ea17ff5a74043) | `taskwarrior-tui: 0.13.34 -> 0.13.35`                                     |
| [`3852a95d`](https://github.com/NixOS/nixpkgs/commit/3852a95d4103c04336427e9cf8c2be8d6b386790) | `tangram: 1.3.1 -> 1.3.2`                                                 |
| [`39e88906`](https://github.com/NixOS/nixpkgs/commit/39e8890675923f2a72331353e07b61f85a379b36) | `trackballs: 1.3.2 -> 1.3.3`                                              |
| [`426d2d2d`](https://github.com/NixOS/nixpkgs/commit/426d2d2d8e23aeb2b3483530e276272e4b5f0b68) | `vaultwarden: 1.22.2 -> 1.23.0`                                           |
| [`26e48252`](https://github.com/NixOS/nixpkgs/commit/26e48252fe35404f3ebeec6c0ed42b76a018f601) | `vcsh: 2.0.2 -> 2.0.4`                                                    |
| [`1a7ed28f`](https://github.com/NixOS/nixpkgs/commit/1a7ed28f7957aeed92b4827186ffaedbfe038228) | `ignite: 0.9.0 -> 0.10.0`                                                 |
| [`2b9ed9c3`](https://github.com/NixOS/nixpkgs/commit/2b9ed9c3e9873317f640f04c8604e06d182ed20f) | `vultr-cli: 2.8.3 -> 2.9.0`                                               |
| [`91e3d8c9`](https://github.com/NixOS/nixpkgs/commit/91e3d8c964261f7e89c545f04d556232496e379e) | `xlog: 2.0.23 -> 2.0.24`                                                  |
| [`dd72fd59`](https://github.com/NixOS/nixpkgs/commit/dd72fd59f8aba1fad1e9dc32cf4c66cc5a05053d) | `terraform: 1.0.9 -> 1.0.10`                                              |
| [`fe4d3d53`](https://github.com/NixOS/nixpkgs/commit/fe4d3d53bad05d8bea60a12af1552457f455d4ac) | `git-lfs: 3.0.1 -> 3.0.2`                                                 |
| [`342035a5`](https://github.com/NixOS/nixpkgs/commit/342035a5d1a272f4a2182c7352e98115491b5e98) | `pkgs/pantheon: set meta.mainProgram`                                     |
| [`2e7ab74e`](https://github.com/NixOS/nixpkgs/commit/2e7ab74e76e75090bcd358460e5e6413fb1ada74) | `amdvlk: 2021.Q3.4 -> 2021.Q3.7`                                          |
| [`28cd68d5`](https://github.com/NixOS/nixpkgs/commit/28cd68d5a47c96758ec469519fe1101a1723e019) | `yubikey-touch-detector: 1.9.1 -> 1.9.3`                                  |
| [`35278505`](https://github.com/NixOS/nixpkgs/commit/352785051db92287d13222db57ae2e8a342535bb) | `protonvpn-gui: build new official client`                                |
| [`a26ebd98`](https://github.com/NixOS/nixpkgs/commit/a26ebd9835c9df9fbe392ad4f041161a0942f3f4) | `python38Packages.protonvpn-nm-lib: init at 3.5.0`                        |
| [`2a6622d7`](https://github.com/NixOS/nixpkgs/commit/2a6622d704aba479f61744a472e26e0ec8075132) | `python38Packages.proton-client: init at 0.7.0`                           |