### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4fe24a325d842bdfe8203d714ee83c1c2c81db62",
-        "sha256": "1zvj1nhwxf8yi8m5yl48gg82krij0gy27hnfi7bhgci792wp5b6x",
+        "rev": "8713cfb52ad747fc6a3ff1d6a0e84d0ce56162f2",
+        "sha256": "0spi5nzr5glpc4ixpgv04jsk27rm9plrz5j2m3nir4v7m8yn8crp",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/4fe24a325d842bdfe8203d714ee83c1c2c81db62.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/8713cfb52ad747fc6a3ff1d6a0e84d0ce56162f2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                   |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
| [`7bbd7efd`](https://github.com/NixOS/nixpkgs/commit/7bbd7efdcb03379dea0a42aeafc25b06508cc336) | `python39Packages.pep257: cleanup`                                                               |
| [`955a657d`](https://github.com/NixOS/nixpkgs/commit/955a657de4206c4270182ca6468c2dfbebd7415b) | `python39Packages.livestreamer: cleanup, remove python2`                                         |
| [`7615b74c`](https://github.com/NixOS/nixpkgs/commit/7615b74cb1b37cbdb619ea9b852e334ac4dfd7db) | `python39Packages.livestreamer-curses: cleanup`                                                  |
| [`205903c9`](https://github.com/NixOS/nixpkgs/commit/205903c9928856e698a1c6660531972f6346bf63) | `python39Packages.audiotools: cleanup`                                                           |
| [`4fa7ac22`](https://github.com/NixOS/nixpkgs/commit/4fa7ac22c48d78b8cbdd931adcb728289a76a1d8) | `nixosTests.cifs-utils: remove`                                                                  |
| [`dedb0147`](https://github.com/NixOS/nixpkgs/commit/dedb014786c097138392f548bea5a9867c2eea9d) | `python3Packages.importlib-resources: 5.2.2 -> 5.4.0`                                            |
| [`3d313212`](https://github.com/NixOS/nixpkgs/commit/3d313212052b415695de4a0737d4dad6c24bd6e4) | `tree-sitter: use CXX to compile C++, optimize and strip`                                        |
| [`f7211380`](https://github.com/NixOS/nixpkgs/commit/f7211380906aa60e42007b656240c126ba4d2e91) | `ssh-tools: 1.6 -> 1.7`                                                                          |
| [`62453006`](https://github.com/NixOS/nixpkgs/commit/62453006868b0adfc8eb7fa0d3701cbab78d429c) | `python3Packages: add pkgs. prefix`                                                              |
| [`059feb3c`](https://github.com/NixOS/nixpkgs/commit/059feb3ccf8f87b3b93bfdd164ab1e43e0298645) | `honcho: 1.0.1 -> 1.1.0, fix the package`                                                        |
| [`6954a396`](https://github.com/NixOS/nixpkgs/commit/6954a396d11feaa1f543fccd3b994ed3db258d26) | `Revert "build(deps): bump zeebe-io/backport-action from 0.0.5 to 0.0.6 (#140848)"`              |
| [`a8ac0dd9`](https://github.com/NixOS/nixpkgs/commit/a8ac0dd94475e5b061adb1e7658151eb2f1186e2) | `Revert "backport-action: 0.0.6 -> 0.0.7"`                                                       |
| [`56c4f9d0`](https://github.com/NixOS/nixpkgs/commit/56c4f9d0052c60aba6b2b8a8a7976cc3f808000d) | `nixosTest: Fix infinite recursion involving hasContext testScript when useNixStoreImage = true` |
| [`9f72692d`](https://github.com/NixOS/nixpkgs/commit/9f72692d125b8a5dc0684a36bf6ffff0774deab3) | `python38Packages.netcdf4: 1.5.7 -> 1.5.8`                                                       |
| [`aad67bd9`](https://github.com/NixOS/nixpkgs/commit/aad67bd968aace87be59fa63858a5810d35f5b82) | `perlPackages.CompressRawLzma: init at 2.101 (#142679)`                                          |
| [`e4e3fbe8`](https://github.com/NixOS/nixpkgs/commit/e4e3fbe8aa4f3a610de91c047b3ea71debeb104e) | `nixos/tests/ghostunnel.nix: Fix eval as invoked by release.nix`                                 |
| [`1d525f51`](https://github.com/NixOS/nixpkgs/commit/1d525f51fbc2f535b7bf4d1d35dafccda7f1f3ed) | `yarn2nix: add nix-prefetch-git to PATH`                                                         |
| [`7bec5411`](https://github.com/NixOS/nixpkgs/commit/7bec54111767242a57bc49bb760bff2ef075a3ca) | `yarn2nix: no sha1 for github tarballs`                                                          |
| [`c78c75ad`](https://github.com/NixOS/nixpkgs/commit/c78c75ad737595999e5dfc46591c18ca772909bd) | `python3Packages: normalise package names in aliases`                                            |
| [`e04b3dc3`](https://github.com/NixOS/nixpkgs/commit/e04b3dc3072c87077f61e624a0c52d6402965cdf) | `python39Packages.lammps-cython: normalise name`                                                 |
| [`2de4ddaf`](https://github.com/NixOS/nixpkgs/commit/2de4ddafcafb1983f3c8588d2a7964bf0ffe61aa) | `python3Packages.iso3166: 1.0.1 -> 2.0.2`                                                        |
| [`78cf2dda`](https://github.com/NixOS/nixpkgs/commit/78cf2dda334ec1ed52bd81d62f10f153bad89a31) | `nixosTests.nixops: Fix deprecation warning`                                                     |
| [`8e353417`](https://github.com/NixOS/nixpkgs/commit/8e35341711fafeaf758807506ef9c616e869b884) | `python38Packages.scikit-survival: 0.15.0.post0 -> 0.16.0`                                       |
| [`195845a1`](https://github.com/NixOS/nixpkgs/commit/195845a10c8f4e99fe83c6d12c96ab3c1ee0377c) | `ocamlPackages.ocaml-top: subsitute version`                                                     |
| [`c1a74608`](https://github.com/NixOS/nixpkgs/commit/c1a746083b6dde8859cd5184f30045d98617d7d0) | `python39Packages.pyspotify: cleanup`                                                            |
| [`ee62f3ea`](https://github.com/NixOS/nixpkgs/commit/ee62f3ea0a1375ec16f5e91eb9d5ab1259951936) | `python39Packages.pycangjie: fix version format`                                                 |
| [`b90d3b02`](https://github.com/NixOS/nixpkgs/commit/b90d3b02a3061d24d80ee9826da6ee4a1e673f1a) | `imagemagick: 7.1.0-11 -> 7.1.0-13`                                                              |
| [`58fda166`](https://github.com/NixOS/nixpkgs/commit/58fda166ed4a7e2540dea07a3ce0d9127cc95d16) | `kitty: fix fontconfig warning during tests`                                                     |
| [`8c938b43`](https://github.com/NixOS/nixpkgs/commit/8c938b431923ee2823ccf84e64a1f88afd85cb78) | `btcpayserver: 1.2.4 -> 1.3.1`                                                                   |
| [`e198a1d7`](https://github.com/NixOS/nixpkgs/commit/e198a1d720dcebce24b136effd009dcebdfbec0c) | `msmtp: 1.8.17 -> 1.8.18`                                                                        |
| [`16e7aa7e`](https://github.com/NixOS/nixpkgs/commit/16e7aa7e7f131e47e0598f070b2e8cf6889e21cb) | `mpop: 1.4.15 -> 1.4.16`                                                                         |
| [`13fad0f8`](https://github.com/NixOS/nixpkgs/commit/13fad0f81b2bd50fd421bd5856a35f1f7c032257) | `nixos/systemd-boot: create boot entries for specialisations`                                    |
| [`1e715d10`](https://github.com/NixOS/nixpkgs/commit/1e715d10b2e31b67453aa4469c0eb40f4fed9903) | `numix-icon-theme: 21.04.14 -> 21.10.31`                                                         |
| [`169a096d`](https://github.com/NixOS/nixpkgs/commit/169a096d26ae7430ded196ecd75ae06c339cf4e6) | `leftwm: 0.2.8 -> 0.2.9`                                                                         |
| [`486ca523`](https://github.com/NixOS/nixpkgs/commit/486ca523c92ded007a0927ed050d10d3631560f9) | `python38Packages.django-storages: 1.12.2 -> 1.12.3`                                             |
| [`fb9c102b`](https://github.com/NixOS/nixpkgs/commit/fb9c102b54ac17cc31618e99a57f5ce9fe94f63f) | `python38Packages.libtmux: 0.10.1 -> 0.10.2`                                                     |
| [`0f44ce8d`](https://github.com/NixOS/nixpkgs/commit/0f44ce8d58189d572f0e52883737c25699029f42) | `jc: 1.17.0 -> 1.17.1`                                                                           |
| [`12fbbf35`](https://github.com/NixOS/nixpkgs/commit/12fbbf3500d1d8514a1774fe5cb837ed0b20d006) | `meteo: 0.9.8 -> 0.9.9`                                                                          |
| [`e6d69fa2`](https://github.com/NixOS/nixpkgs/commit/e6d69fa20ede8a37a71cbd3d93483b09b7448e31) | `trash-cli: 0.21.7.24 -> 0.21.10.24`                                                             |
| [`069d3c8a`](https://github.com/NixOS/nixpkgs/commit/069d3c8abd626a8a2d3e8e6db51d42cfbedb9a7b) | `python3Packages.angrcli: init at 1.1.1`                                                         |
| [`54c353d0`](https://github.com/NixOS/nixpkgs/commit/54c353d0b0173abb3337b491d18e7cadd47c4ad9) | `python38Packages.base58: 2.1.0 -> 2.1.1`                                                        |
| [`597eb07e`](https://github.com/NixOS/nixpkgs/commit/597eb07e00d7173ec8f7287e54080715e608df4f) | `yices: drop symlink hack, avoid ldconfig on linux`                                              |
| [`5ce69b0b`](https://github.com/NixOS/nixpkgs/commit/5ce69b0b2db2e669f6bca44a6f9e31238f43a20b) | `esbuild: 0.13.10 -> 0.13.11`                                                                    |
| [`f136a08a`](https://github.com/NixOS/nixpkgs/commit/f136a08a3bfa2cc6fb7d969fbcfa583a95ec0bf0) | `python3Packages.upass: add pythonImportsCheck`                                                  |
| [`ad6ad9af`](https://github.com/NixOS/nixpkgs/commit/ad6ad9af78b44025c99865b3139dd3ce9a21cb56) | `python38Packages.upass: 0.1.4 -> 0.2.1`                                                         |
| [`0e1318f8`](https://github.com/NixOS/nixpkgs/commit/0e1318f826a7320c7dd0db3bc3160ee583d61357) | `python3Packages.pex: add pythonImportsCheck`                                                    |
| [`a2445c74`](https://github.com/NixOS/nixpkgs/commit/a2445c740efa0f5a34c1756dd28812e1b12d0b24) | `coqPackages.dpdgraph: 0.6.9 → 1.0`                                                              |
| [`674eb91f`](https://github.com/NixOS/nixpkgs/commit/674eb91f4cad2d0cce67b3e8e6080b409c45f0e2) | `python38Packages.aenum: 3.1.0 -> 3.1.1`                                                         |
| [`44883e70`](https://github.com/NixOS/nixpkgs/commit/44883e70cc9b40d104d3a1cbdd7b576815aa08e0) | `quaternion: 0.0.95 - 0.0.95.1`                                                                  |
| [`2cfa8b55`](https://github.com/NixOS/nixpkgs/commit/2cfa8b5511381f629abd0cec2ff5e8c988ec0298) | `libquotient: 0.6.9 -> 0.6.11`                                                                   |
| [`19c1eb37`](https://github.com/NixOS/nixpkgs/commit/19c1eb3710c5de9ff23f3e928e552bc703886b95) | `ttyd: enable on darwin`                                                                         |
| [`f8f15d06`](https://github.com/NixOS/nixpkgs/commit/f8f15d06acdc439795923139eb9cea1e3f2f55cf) | `python38Packages.pex: 2.1.52 -> 2.1.53`                                                         |
| [`b232c81a`](https://github.com/NixOS/nixpkgs/commit/b232c81a32c78ab1c2e4b13796a8149a375b6df7) | `virtualbox: 6.1.26 -> 6.1.28`                                                                   |
| [`27ba20dd`](https://github.com/NixOS/nixpkgs/commit/27ba20dd72d523656b4aec6ce46f7c5dffb09dd4) | `linuxPackages.vm-tools: init`                                                                   |
| [`788920fc`](https://github.com/NixOS/nixpkgs/commit/788920fcdf8fff2fb3eb0a70d00822a45ecd454f) | `nixosTests.rasdaemon: init module test`                                                         |
| [`e1437878`](https://github.com/NixOS/nixpkgs/commit/e14378789c9d8fe571980af14cbdcd31cdca06b6) | `nixos/rl-2111: add new service: rasdaemon`                                                      |
| [`b6ff276f`](https://github.com/NixOS/nixpkgs/commit/b6ff276fb18991c71dd2a2e05ea81c9055cb908d) | `nixos/rasdaemon: init module`                                                                   |
| [`ea0e9dac`](https://github.com/NixOS/nixpkgs/commit/ea0e9dac2a8de2c6cd67507c41c8f915557eafc1) | `error-inject: init mce, edac and aer`                                                           |
| [`93f3805d`](https://github.com/NixOS/nixpkgs/commit/93f3805d8847b6fdfcc06022841c3274066df522) | `rasdaemon: init at 0.6.7`                                                                       |
| [`91bab151`](https://github.com/NixOS/nixpkgs/commit/91bab1510b668e7b9d18f0d77e52674780c91146) | `gitRepo: 2.17.2 -> 2.17.3`                                                                      |
| [`12fe0fae`](https://github.com/NixOS/nixpkgs/commit/12fe0fae03d81be4843ba2e34bc5fb07a0a3ea9e) | `arrow-cpp: 5.0.0 -> 6.0.0 (#143422)`                                                            |
| [`7237eb40`](https://github.com/NixOS/nixpkgs/commit/7237eb405e1442b318d1d2aa0e2508d5a5b71f73) | `getmail6: 6.18.4 -> 6.18.5`                                                                     |
| [`eab875b0`](https://github.com/NixOS/nixpkgs/commit/eab875b05748b68131a8920d91549574a337f297) | `flexget: 3.1.148 -> 3.1.149`                                                                    |
| [`cadbf505`](https://github.com/NixOS/nixpkgs/commit/cadbf50512ed03be55b395110ffbfe27f0aa3b82) | `vimPlugins.lean-nvim: init at 2021-10-30`                                                       |
| [`cb8398c8`](https://github.com/NixOS/nixpkgs/commit/cb8398c8171a1b473f76da223bb3f91fd39a4347) | `pantheon.elementary-videos: 2.7.3 -> 2.8.0`                                                     |
| [`e93b752b`](https://github.com/NixOS/nixpkgs/commit/e93b752b9ee784385a75f1a55cbbf33264f40b2f) | `pantheon.elementary-default-settings: 6.0.1 -> 6.0.2`                                           |
| [`e8cf60ff`](https://github.com/NixOS/nixpkgs/commit/e8cf60ffb47ea21e90e208ae54a72a4a7140250f) | `pantheon.wingpanel-indicator-datetime: 2.3.0 -> 2.3.1`                                          |
| [`2ffa2785`](https://github.com/NixOS/nixpkgs/commit/2ffa278547e50091c091cd4abdc8c7ac827e0f2c) | `heisenbridge: 1.4.0 -> 1.4.1`                                                                   |
| [`6eea3076`](https://github.com/NixOS/nixpkgs/commit/6eea3076328065cfcb08daf48f196280d05a6da3) | `clojure: 1.10.3.998 -> 1.10.3.1013`                                                             |
| [`44678987`](https://github.com/NixOS/nixpkgs/commit/446789875d836ca198a0d91f7e4a9553d2e258d8) | `weylus: 0.11.2 -> 0.11.3`                                                                       |
| [`e9c996a9`](https://github.com/NixOS/nixpkgs/commit/e9c996a93046e7cb2bd0deeb24d03355ddad933a) | `python3Packages.async-upnp-client: 0.22.8 -> 0.22.10`                                           |
| [`a839f10b`](https://github.com/NixOS/nixpkgs/commit/a839f10be8fd6c2720a37460fc7bb20d9c9d7f72) | `python3Packages.python-didl-lite: 1.3.0 -> 1.3.1`                                               |
| [`3f189f86`](https://github.com/NixOS/nixpkgs/commit/3f189f860dfdd54ac8743da98dfa5fd2448325f3) | `gnome.gpaste: 3.42.0 → 3:42.1`                                                                  |
| [`61abd625`](https://github.com/NixOS/nixpkgs/commit/61abd625e6b7ac261934933c09f3396c02110509) | `terraform-docs: 0.15.0 -> 0.16.0 (#143354)`                                                     |
| [`265a4f8a`](https://github.com/NixOS/nixpkgs/commit/265a4f8a1a485e274c1302bee56faae8b74f2ad6) | `checkov: 2.0.509 -> 2.0.528`                                                                    |
| [`cd959648`](https://github.com/NixOS/nixpkgs/commit/cd959648e51ffd3e33714796ed52c6cd837761b3) | `seafile-client: take over maintenance of this package`                                          |
| [`045fe246`](https://github.com/NixOS/nixpkgs/commit/045fe2465cacb7d91a623c6d01daf07ecc28e17b) | `python38Packages.scikit-fmm: 2021.9.23 -> 2021.10.29`                                           |
| [`238bd957`](https://github.com/NixOS/nixpkgs/commit/238bd957ac0d845b2f355a781fc3aa890d8079c1) | `python3Packages.aiounifi: 28 -> 29`                                                             |
| [`1f911dc7`](https://github.com/NixOS/nixpkgs/commit/1f911dc73cf4c61edb4fa88d9d537c26acfe95dd) | `googleearth-pro: 7.3.3.7786 -> 7.3.4.8248`                                                      |
| [`fe283003`](https://github.com/NixOS/nixpkgs/commit/fe2830036621bff58ed0becc6261e66f72987817) | `devpi-client: fix build`                                                                        |
| [`7210e094`](https://github.com/NixOS/nixpkgs/commit/7210e0946f24ac3aa881d64dd659bbea606ea33b) | `python38Packages.flask-paginate: 2021.10.26 -> 2021.10.29`                                      |
| [`2cac2511`](https://github.com/NixOS/nixpkgs/commit/2cac2511d73e8a8817e0e34d59928d418df14a8c) | `azure-cli: 2.28.1 -> 2.29.1`                                                                    |
| [`59af9bd8`](https://github.com/NixOS/nixpkgs/commit/59af9bd85580057fb6ba3130fa94a49fea109d81) | `arcan.arcan: fix static openal issues`                                                          |
| [`21772bfc`](https://github.com/NixOS/nixpkgs/commit/21772bfcce94e9a0ebb60481be2eb39a5704e4ca) | `python3Packages.regenmaschine: 3.2.0 -> 2021.10.0`                                              |
| [`3ae7509c`](https://github.com/NixOS/nixpkgs/commit/3ae7509c2c1094fc7a3ab49a1ef79360ab300c07) | `i3: 4.19.2 -> 4.20`                                                                             |
| [`4a4cb4b9`](https://github.com/NixOS/nixpkgs/commit/4a4cb4b942a70ac89b1c8a42caf307bd33b0c1cf) | `exploitdb: 2021-10-23 -> 2021-10-30`                                                            |
| [`198253c6`](https://github.com/NixOS/nixpkgs/commit/198253c6a3e2d876ab16ecff57518818864f4d00) | `metasploit: 6.1.11 -> 6.1.12`                                                                   |
| [`8a2856d9`](https://github.com/NixOS/nixpkgs/commit/8a2856d973815e8cbeb8813d673192b1eb05d00d) | `kyocera-ecosys-m2x35-40-p2x35-40dnw: init at 8.1606`                                            |
| [`97614c39`](https://github.com/NixOS/nixpkgs/commit/97614c396db35ee2382631afb93a7471beab19c5) | `vtk_9_withQt5: add`                                                                             |
| [`69616b86`](https://github.com/NixOS/nixpkgs/commit/69616b862f2d57fb25b4724501be2068a7bb20db) | `sub-batch: 0.4.0 -> 0.4.1`                                                                      |
| [`bb9ea676`](https://github.com/NixOS/nixpkgs/commit/bb9ea6763d1e4ef7f94a91cf056bc245ac39ce4b) | `nixosTests.installed-tests.power-profiles-daemon: init`                                         |
| [`868157b9`](https://github.com/NixOS/nixpkgs/commit/868157b9d6b53f385eba993320f97a182c9d6ed7) | `nixos/nextcloud: Adapt cron frequency to changed upstream requirement`                          |
| [`ff2ad643`](https://github.com/NixOS/nixpkgs/commit/ff2ad6435340d27d0fc55e6cd4913393e9ef0440) | `lsd: move nixos test to installCheckPhase`                                                      |
| [`d44db8dd`](https://github.com/NixOS/nixpkgs/commit/d44db8ddaa68efcf16218233f071abec9039858e) | `kicad: 5.1.10 -> 5.1.11`                                                                        |
| [`e33e6a06`](https://github.com/NixOS/nixpkgs/commit/e33e6a064d36e4e16eefcc3113abfbc1b72133bb) | `victor-mono: 1.4.1 -> 1.5.0`                                                                    |
| [`c435ff18`](https://github.com/NixOS/nixpkgs/commit/c435ff1802dd17d3106ae1cedbb8caf070ad9f0d) | `source-han-code-jp: 2.011R -> 2.012R`                                                           |
| [`36d6f480`](https://github.com/NixOS/nixpkgs/commit/36d6f48076e959df7119db850f993fc07e995ea9) | `ibm-plex: 5.1.3 -> 6.0.0`                                                                       |
| [`e927818e`](https://github.com/NixOS/nixpkgs/commit/e927818ed93d47231876d60662977994a46162b8) | `spirv-tools: 2020.2 -> 2021.3`                                                                  |
| [`e0e573fc`](https://github.com/NixOS/nixpkgs/commit/e0e573fc8cd4f8b161917ded60ec2f8311a50b10) | `spirv-headers: 1.5.3 -> unstable-2021-08-11`                                                    |
| [`cdb3214f`](https://github.com/NixOS/nixpkgs/commit/cdb3214f269edd841ab3fa1c748c94e663397f62) | `draco: 1.4.1 -> 1.4.3`                                                                          |
| [`d6782983`](https://github.com/NixOS/nixpkgs/commit/d6782983d66ea6e5455cffa5be4ac729b79fa4a8) | `scalafmt: 3.0.0 → 3.0.8`                                                                        |
| [`705e4006`](https://github.com/NixOS/nixpkgs/commit/705e4006aea59caeabe4ef827b16f551616f6795) | `hal-hardware-analyzer: 3.2.6 -> 3.3.0`                                                          |
| [`810b3b5f`](https://github.com/NixOS/nixpkgs/commit/810b3b5fcd2632ca9d54f939f9abb4ceaf33e8bc) | `nixos/yubikey-agent add maintainer jwoudenberg`                                                 |
| [`4ceb33b9`](https://github.com/NixOS/nixpkgs/commit/4ceb33b982d71ca1cc593482efc04b64fa44353c) | `nixos/yubikey-agent: start enabled agent on boot`                                               |
| [`b2a6a80c`](https://github.com/NixOS/nixpkgs/commit/b2a6a80ce5542a6e495d4198b46000f160047291) | `android-studio-beta: 2021.1.1.14 → 2021.1.1.15`                                                 |
| [`e9fe9d22`](https://github.com/NixOS/nixpkgs/commit/e9fe9d22e89e33fe102206125b363928a7ba06fa) | `python3Packages.asn1: 2.4.1 -> 2.4.2`                                                           |
| [`d705e129`](https://github.com/NixOS/nixpkgs/commit/d705e129babd421f65a932f8e0893f9f9063d507) | `python3Packages.adafruit-platformdetect: 3.16.1 -> 3.17.1`                                      |
| [`5b5798cd`](https://github.com/NixOS/nixpkgs/commit/5b5798cd0ced66d6954e04673595cbc97202d97c) | `python3Packages.smbprotocol: 1.8.0 -> 1.8.1`                                                    |
| [`700c0c5b`](https://github.com/NixOS/nixpkgs/commit/700c0c5be3ecfc58503a7efaf2e9bfa94c1150ea) | `freerdp: 2.4.0 -> 2.4.1`                                                                        |
| [`14908b79`](https://github.com/NixOS/nixpkgs/commit/14908b79fbf331906bd4803b225cc35fe18e705f) | `dnscrypt-proxy2: 2.1.0 -> 2.1.1`                                                                |
| [`1a615778`](https://github.com/NixOS/nixpkgs/commit/1a61577867c7409b2b5353b5fb8eda841816e25d) | `distrobuilder: 1.3 -> 2.0`                                                                      |
| [`4471d9c0`](https://github.com/NixOS/nixpkgs/commit/4471d9c0f45fe33da05d4fbf07a3239b3e58eb34) | `dalfox: 2.5.2 -> 2.5.4`                                                                         |
| [`0e8a13bc`](https://github.com/NixOS/nixpkgs/commit/0e8a13bc187ad761931c847b4772d8a8a9addca0) | `qt5ct: 1.3 -> 1.5`                                                                              |
| [`6e64f03c`](https://github.com/NixOS/nixpkgs/commit/6e64f03c12ef2636d86bde242cacc3b9d2ba9b8e) | `nixosTests.power-profiles-daemon: add to all-tests.nix`                                         |
| [`046ec823`](https://github.com/NixOS/nixpkgs/commit/046ec823465877ce67d7209b2be2f94c38205ef2) | `power-profiles-daemon: 0.8.1 → 0.10.1`                                                          |
| [`6fe26321`](https://github.com/NixOS/nixpkgs/commit/6fe263218853328a1b438fd8fd37f1115fc704d3) | `cherrytree: 0.99.41 -> 0.99.42`                                                                 |
| [`570c2194`](https://github.com/NixOS/nixpkgs/commit/570c2194c50e6e7c5dc15f33e88dfe0a3f67d721) | `cargo-release: 0.17.1 -> 0.18.2`                                                                |
| [`f475cb61`](https://github.com/NixOS/nixpkgs/commit/f475cb61b85ef78dfb99a15bd9d5a2c3e6fdeb23) | `cargo-make: 0.35.0 -> 0.35.5`                                                                   |
| [`e21ca5fa`](https://github.com/NixOS/nixpkgs/commit/e21ca5fa57c88f45681a6be628ebabcf487c5dec) | `android-studio-canary: 2021.2.1.2 → 2021.2.1.3`                                                 |
| [`da665b7e`](https://github.com/NixOS/nixpkgs/commit/da665b7e6e1ff98b3ba4c620c81f2ade4dfc0b82) | `prometheus-redis-exporter: 1.23.1 -> 1.29.0`                                                    |
| [`16fe79ea`](https://github.com/NixOS/nixpkgs/commit/16fe79eaf6f50b310bf7f32b749c06834ea023d5) | `rr: 5.4.0 -> 5.5.0`                                                                             |
| [`2ae925d4`](https://github.com/NixOS/nixpkgs/commit/2ae925d413f1fb04918c1d1447c76d4d07dd9f7f) | `rpcbind: 1.2.5 -> 1.2.6`                                                                        |
| [`ca5b6b9c`](https://github.com/NixOS/nixpkgs/commit/ca5b6b9cafacc208cf13cff3bcd9d782333bbad3) | `linkerd: 2.11.0 -> 2.11.1`                                                                      |
| [`c8b37127`](https://github.com/NixOS/nixpkgs/commit/c8b3712719a30ee987c65ec13771efa746233098) | `python38Packages.phonenumbers: 8.12.35 -> 8.12.36`                                              |
| [`fadabada`](https://github.com/NixOS/nixpkgs/commit/fadabada422320a826591fefadbc66f8ee4bfac4) | `python3.pkgs.ihatemoney: add release notes`                                                     |
| [`e28414b6`](https://github.com/NixOS/nixpkgs/commit/e28414b63dd4161e3d8f32a6779fe2df52091302) | `python3.pkgs.ihatemoney: 4.2 -> 5.1.1`                                                          |
| [`7e90cdb3`](https://github.com/NixOS/nixpkgs/commit/7e90cdb3b1d438d595ffc8d1d3aabb91aa8f6330) | `thanos: 0.22.0 -> 0.23.1`                                                                       |
| [`244266c2`](https://github.com/NixOS/nixpkgs/commit/244266c29792ea7dd344e81e1b586aa98f5ae2b5) | `uptimed: 0.4.4 -> 0.4.5`                                                                        |
| [`2bbd6910`](https://github.com/NixOS/nixpkgs/commit/2bbd691041b6590044cea3602f8886937a56e517) | `uftrace: 0.10 -> 0.11`                                                                          |
| [`ec6e1b27`](https://github.com/NixOS/nixpkgs/commit/ec6e1b27f06b68a0e3f08480dda54d33cf91a9ed) | `dump1090: 5.0 → 6.1`                                                                            |
| [`18451cb5`](https://github.com/NixOS/nixpkgs/commit/18451cb59a89470d587d7265c95d4d9b2938d75d) | `qemu: fix CVE-2021-3713`                                                                        |
| [`3bd2ecaf`](https://github.com/NixOS/nixpkgs/commit/3bd2ecaf3372f29e2f0409ed810ed34c168d6553) | `linuxKernel.kernels.linux_xanmod: 5.14.14-2 -> 5.14.15-1`                                       |
| [`67c9fdf2`](https://github.com/NixOS/nixpkgs/commit/67c9fdf26abea1ce1daf55d59cf97be41c070173) | `netpbm: 10.92.0 -> 10.96.2`                                                                     |
| [`34ba7d2f`](https://github.com/NixOS/nixpkgs/commit/34ba7d2fdc6bc624324758b493e8c90fc0eb388e) | `discourse.plugins.discourse-voting: Init`                                                       |
| [`3251a4a7`](https://github.com/NixOS/nixpkgs/commit/3251a4a7d2df899598b96518ba1d5ce339ba96f1) | `discourse.plugins.discourse-saved-searches: Init`                                               |
| [`75843437`](https://github.com/NixOS/nixpkgs/commit/7584343790a8d981433385e2beeef485e574e2f3) | `discourse.plugins.discourse-prometheus: Init`                                                   |
| [`9ede32d4`](https://github.com/NixOS/nixpkgs/commit/9ede32d45ca6e54c81de2ef43beb78c7067e7f0c) | `discourse.plugins.discourse-docs: Init`                                                         |
| [`ecb1b736`](https://github.com/NixOS/nixpkgs/commit/ecb1b736c702e1e7228b6419726b3c8bc0ec2a6f) | `discourse.plugins.discourse-chat-integration: Init`                                             |
| [`1ef543a5`](https://github.com/NixOS/nixpkgs/commit/1ef543a549ab4206c68ab3d05bce07ec9e178426) | `discourse.plugins.discourse-assign: Init`                                                       |
| [`d91e26fa`](https://github.com/NixOS/nixpkgs/commit/d91e26fa42b723da301cc8e2ed8b378318e4d63d) | `python3Packages.tuya-iot-py-sdk: 0.6.2 -> 0.6.3`                                                |
| [`6f4ceb93`](https://github.com/NixOS/nixpkgs/commit/6f4ceb9393b27292359c9c907edf7611f3c462d7) | `python3Packages.tuya-iot-py-sdk: 0.5.0 -> 0.6.2`                                                |
| [`b3bcf51c`](https://github.com/NixOS/nixpkgs/commit/b3bcf51c05aa4a1929d623cf01722a271da74888) | `pipewire: 0.3.38 -> 0.3.39`                                                                     |
| [`b65f74fd`](https://github.com/NixOS/nixpkgs/commit/b65f74fd98b06a84a67b66138d31be8419612c09) | `pipewire-media-session: init at 0.4.0`                                                          |
| [`076ffa9c`](https://github.com/NixOS/nixpkgs/commit/076ffa9cf0732de37e92c4dfbe8c0eb1a5169cbe) | `python3Packages.flask-talisman: init at 0.8.1`                                                  |
| [`9f34b86c`](https://github.com/NixOS/nixpkgs/commit/9f34b86c595599bf1ba47aae7b9d8155cda0f09f) | `opendkim: fix darwin`                                                                           |