### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8713cfb52ad747fc6a3ff1d6a0e84d0ce56162f2",
-        "sha256": "0spi5nzr5glpc4ixpgv04jsk27rm9plrz5j2m3nir4v7m8yn8crp",
+        "rev": "6d7a5212c5c2cb8a873477927078ed53a028307b",
+        "sha256": "0xcd9527qcak0g06n4xnaz76gzj9m6x5gfnqmsq9rapjvmxinnhv",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/8713cfb52ad747fc6a3ff1d6a0e84d0ce56162f2.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/6d7a5212c5c2cb8a873477927078ed53a028307b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                     |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`f74fb8c4`](https://github.com/NixOS/nixpkgs/commit/f74fb8c45d4d41f8cac6594f6b2eb8bd1278a708) | `crowdin-cli: 3.7.0 -> 3.7.1`                                                      |
| [`0b0d2637`](https://github.com/NixOS/nixpkgs/commit/0b0d2637fca96a4e4d7fac4c40e0773bc218ff53) | `Revert "nixos/specialisation: Rephrase in terms of extendModules, noUserModules"` |
| [`e2bea442`](https://github.com/NixOS/nixpkgs/commit/e2bea4427bcf03ae168e45e0bcbd92ac678d91ce) | `nixos/specialisation: Rephrase in terms of extendModules, noUserModules`          |
| [`86f5136b`](https://github.com/NixOS/nixpkgs/commit/86f5136bafec4a6208ffe23e870f74c731f849de) | `modules: Update evalModules doc`                                                  |
| [`22584ce6`](https://github.com/NixOS/nixpkgs/commit/22584ce6675fdabd14fd71f7ce8021cd14facf05) | `nixos/eval-config.nix: Expose type`                                               |
| [`64dfd983`](https://github.com/NixOS/nixpkgs/commit/64dfd983df61d9c427ac01d0d25b8d2f26b4c3d5) | `modules: Add visible = "shallow" to hide only sub-options`                        |
| [`27644a82`](https://github.com/NixOS/nixpkgs/commit/27644a82a99b4855e40dfd6c09d7288664217662) | `modules: Add extendModules to module args`                                        |
| [`dece37b8`](https://github.com/NixOS/nixpkgs/commit/dece37b83a46d488787859332e18286727b96cc4) | `lib.evalModules: Add extendModules and type to result`                            |
| [`9ec2134b`](https://github.com/NixOS/nixpkgs/commit/9ec2134b6864019849f4fc267ecab6ddd88e9cea) | `statix: 0.3.1 -> 0.3.4`                                                           |
| [`8d8a17f8`](https://github.com/NixOS/nixpkgs/commit/8d8a17f889e7df0b7742505ea87ee4dce1a83433) | `lemmy: 0.12.2 -> 0.13.3`                                                          |
| [`f1d3cdcf`](https://github.com/NixOS/nixpkgs/commit/f1d3cdcf58803275486579e3e088d4d333672eff) | `lemmy: use pin.json to prepare for update script`                                 |
| [`9a3e6e22`](https://github.com/NixOS/nixpkgs/commit/9a3e6e22534e51dc68bd80730df5ad54e2aaa521) | `lemmy-ui: use fetchyarndeps`                                                      |
| [`c0b0059e`](https://github.com/NixOS/nixpkgs/commit/c0b0059e8a4ffd9189f318afb2d16ca78bb415cc) | `ns-3: 3.34 -> 3.35`                                                               |
| [`7638773c`](https://github.com/NixOS/nixpkgs/commit/7638773c6a5d9ec7d058d057367bb64c05eed934) | `vimPlugins.lingua-franca: init at 2021-9-5 (#144040)`                             |
| [`714db3b5`](https://github.com/NixOS/nixpkgs/commit/714db3b557bf98498143a4ac4d9e68f66817bec6) | `qimgv: 1.0.1 -> 1.0.2`                                                            |
| [`a13b5c3e`](https://github.com/NixOS/nixpkgs/commit/a13b5c3ecb96c0332017fa01eb3a6e3a83711fc2) | `maintainers: add matrix id for ekleog (#144050)`                                  |
| [`11a1d227`](https://github.com/NixOS/nixpkgs/commit/11a1d227b28121732a771b3ef2b973ada3dcfc00) | `weylus: 0.11.3 -> 0.11.4`                                                         |
| [`ec051184`](https://github.com/NixOS/nixpkgs/commit/ec051184292886757d567ffe9fe09be7b97f92bc) | `clpm: 0.3.6 -> 0.4.1 (#143163)`                                                   |
| [`78709f61`](https://github.com/NixOS/nixpkgs/commit/78709f61dad7bdebfaa1403ae841a3f937a75861) | `entangle: init at 3.0`                                                            |
| [`a1bbe130`](https://github.com/NixOS/nixpkgs/commit/a1bbe1306e4d09567d50b8b4ab5bcfbf43743b4e) | `SHADERed: 1.4.1 -> 1.5.6 (#143915)`                                               |
| [`f990fb9f`](https://github.com/NixOS/nixpkgs/commit/f990fb9fcbdd7c2fb20f8e13206de0e4606337da) | `python38Packages.skorch: 0.10.0 -> 0.11.0`                                        |
| [`4bdb1450`](https://github.com/NixOS/nixpkgs/commit/4bdb1450539bc8da526be187153b3c1fa8339e42) | `rakudo: fix darwin sharedLibrary path`                                            |
| [`925ab444`](https://github.com/NixOS/nixpkgs/commit/925ab444c96020343f265a0e7531e991158234f8) | `elan: 1.1.0 -> 1.2.0`                                                             |
| [`eb7d94e6`](https://github.com/NixOS/nixpkgs/commit/eb7d94e6e3adb3b73b7969ce549f1a5dff65c84c) | `sublime{4,-merge}: Update packages.`                                              |
| [`0d127542`](https://github.com/NixOS/nixpkgs/commit/0d127542671c99e45de4e355592a25e955daac4a) | `python3Packages.icmplib: 3.0.1 -> 3.0.2`                                          |
| [`db200332`](https://github.com/NixOS/nixpkgs/commit/db2003322d7ed7707e7b5516bade23f3b61b93f5) | `python3Packages.ibis: 1.6.0 -> 3.2.0`                                             |
| [`0995b30c`](https://github.com/NixOS/nixpkgs/commit/0995b30c341709660ff25b598e0a52f37e119bae) | `nix-du: 0.3.3 -> 0.4`                                                             |
| [`5e1c94ef`](https://github.com/NixOS/nixpkgs/commit/5e1c94effd0ea9696376dd5c9ab325a2d76514d5) | `neomutt: 20211022 -> 20211029`                                                    |
| [`0182d404`](https://github.com/NixOS/nixpkgs/commit/0182d4040348dbe481bc5e897cc504e0134fd6e3) | `sedutil: 1.15.1 -> 1.20.0`                                                        |
| [`c348f7c1`](https://github.com/NixOS/nixpkgs/commit/c348f7c17d9960b618252db428aa3612dd0ee856) | `gnome.tali: 40.3 → 40.4`                                                          |
| [`78946b0e`](https://github.com/NixOS/nixpkgs/commit/78946b0e98230a1eea6660645250b1fccc62e58a) | `gnome.nautilus: 41.0 → 41.1`                                                      |
| [`1ae58eb5`](https://github.com/NixOS/nixpkgs/commit/1ae58eb531b9dca930f2270df9c0a910d69e9d6c) | `gnome.libgnome-games-support: 1.8.1 → 1.8.2`                                      |
| [`a3dca903`](https://github.com/NixOS/nixpkgs/commit/a3dca903bb0d551b234f1889471156026af9ecfb) | `gnome.gnome-terminal: 3.42.0 → 3.42.1`                                            |
| [`d984d321`](https://github.com/NixOS/nixpkgs/commit/d984d321b4834f73013b528791478b8f6b820253) | `gnome.gnome-remote-desktop: 41.0 → 41.1`                                          |
| [`7508b25a`](https://github.com/NixOS/nixpkgs/commit/7508b25ad0c4cc51bd72603f373d1573f86f4e33) | `gnome.gnome-maps: 41.0 → 41.1`                                                    |
| [`467f55e8`](https://github.com/NixOS/nixpkgs/commit/467f55e87ea47362ba3f2d5d804e5a9d3496bef8) | `gnome.gnome-chess: 41.0 → 41.1`                                                   |
| [`81271ee4`](https://github.com/NixOS/nixpkgs/commit/81271ee4c12eab7c55615ef6f2538bbd3691fd8b) | `gnome.gnome-autoar: 0.4.0 → 0.4.1`                                                |
| [`957284c6`](https://github.com/NixOS/nixpkgs/commit/957284c69017d6e9dabd655b1897ab02491d54ca) | `sniffglue: 0.13.1 -> 0.14.0`                                                      |
| [`dd4e65d6`](https://github.com/NixOS/nixpkgs/commit/dd4e65d6201106fa0e90aede42f743c3b8b4ed89) | `gnome.aisleriot: 3.22.17 → 3.22.19`                                               |
| [`a5d70a83`](https://github.com/NixOS/nixpkgs/commit/a5d70a83eb38e87dba9387164f86fc5e5812203c) | `gnome-recipes: 2.0.2 → 2.0.4`                                                     |
| [`a20a4af6`](https://github.com/NixOS/nixpkgs/commit/a20a4af62aee6f338f81cd16e988bea3878adf59) | `maintainers/scripts/update.nix: Support committing with nix-update-script`        |
| [`f270c529`](https://github.com/NixOS/nixpkgs/commit/f270c529ce51cb462db2331629dcee64879dfdf5) | `dleyna-renderer: 0.7.1 → 0.7.2`                                                   |
| [`ae3dc2d9`](https://github.com/NixOS/nixpkgs/commit/ae3dc2d9749ff2ea1f6cafacb509b0e14c73faa2) | `dleyna-server: 0.7.1 → 0.7.2`                                                     |
| [`674a09e6`](https://github.com/NixOS/nixpkgs/commit/674a09e6c2d853919e73139b489aa64ba5f70203) | `acpica-tools: 20210730 -> 20210930`                                               |
| [`36e0ff5f`](https://github.com/NixOS/nixpkgs/commit/36e0ff5fedec8c1c901cd44b97870e7188d47c6a) | `logseq: 0.4.2 -> 0.4.5`                                                           |
| [`9e431da5`](https://github.com/NixOS/nixpkgs/commit/9e431da51578ff00600d1fa5b25b8ffcd7a6afd3) | `ammonite: move nixos test to installCheckPhase`                                   |
| [`bcbb7d97`](https://github.com/NixOS/nixpkgs/commit/bcbb7d97dccfee7c67f282cc0fa71688fc0ab503) | `lf: 25 -> 26`                                                                     |
| [`21acfcd9`](https://github.com/NixOS/nixpkgs/commit/21acfcd96353f793d069abd8a3b757d3fa015bfe) | `sarasa-gothic: 0.32.9 -> 0.34.7`                                                  |
| [`948727d8`](https://github.com/NixOS/nixpkgs/commit/948727d87270294c444ff6aff736b60a491d0298) | `awscli: move nixos test to installCheckPhase`                                     |
| [`cd6800cb`](https://github.com/NixOS/nixpkgs/commit/cd6800cbff91b4f8d3060ece448ea31d16adbea7) | `plexamp: use new pname-version cababilities introduced in #143347`                |
| [`d654d52b`](https://github.com/NixOS/nixpkgs/commit/d654d52b24a93a4e1be65227db092ca769c614ee) | `nvidia_x11_legacy470: 470.74 -> 470.82.00`                                        |
| [`d06d1bb0`](https://github.com/NixOS/nixpkgs/commit/d06d1bb0095f01a9723e36ccd01c6c8625ff3420) | `nvidia_x11_legacy470: add linuxPackages alias`                                    |
| [`73b1963d`](https://github.com/NixOS/nixpkgs/commit/73b1963d26811d5b008f29c5a1b4d216148115a4) | `python38Packages.impacket: 0.9.23 -> 0.9.24`                                      |
| [`6608fb61`](https://github.com/NixOS/nixpkgs/commit/6608fb61ce43cf259b785f476255c88dc68ea33f) | `xfce.xfdashboard: 0.9.4 -> 0.9.5`                                                 |
| [`53db46df`](https://github.com/NixOS/nixpkgs/commit/53db46dfcf7d5d9548b49e8d7433a51eeec0f340) | `python38Packages.google-resumable-media: 2.0.3 -> 2.1.0`                          |
| [`84bcaa29`](https://github.com/NixOS/nixpkgs/commit/84bcaa29c25c0365cb96eda0b2338374a6785948) | `python38Packages.google-cloud-trace: 1.4.0 -> 1.5.0`                              |
| [`040b4a51`](https://github.com/NixOS/nixpkgs/commit/040b4a51e125e75d4221d292e198cb03ac8c3713) | `python38Packages.google-cloud-texttospeech: 2.6.0 -> 2.7.0`                       |
| [`c80cdee1`](https://github.com/NixOS/nixpkgs/commit/c80cdee123f1fdb439906fe90849565128863aa9) | `python38Packages.google-cloud-tasks: 2.6.0 -> 2.7.0`                              |
| [`c6530346`](https://github.com/NixOS/nixpkgs/commit/c6530346b4a246190fd104c6c18b545772519cf6) | `python38Packages.google-cloud-os-config: 1.6.0 -> 1.7.0`                          |
| [`a5e6f42b`](https://github.com/NixOS/nixpkgs/commit/a5e6f42b6eeadb4d68c34d63e7bb19834e456147) | `python38Packages.google-cloud-dataproc: 3.0.0 -> 3.1.0`                           |
| [`bf0c0cc7`](https://github.com/NixOS/nixpkgs/commit/bf0c0cc767e6abfe0c319208359c8012029371e8) | `pidgin: use system certificates to fix letsencrypt`                               |
| [`2fc86342`](https://github.com/NixOS/nixpkgs/commit/2fc86342f1a7c0710a8ba4cac32cd7709f6d7c80) | `python38Packages.google-cloud-resource-manager: 1.2.0 -> 1.3.0`                   |
| [`2f2dd91b`](https://github.com/NixOS/nixpkgs/commit/2f2dd91b7b8db7d5a5bf8f9c8f0a3cef8d631ee5) | `python38Packages.google-cloud-videointelligence: 2.4.0 -> 2.5.0`                  |
| [`92ce543e`](https://github.com/NixOS/nixpkgs/commit/92ce543e87c1c30aba4fd0212371adcacaebd85e) | `python38Packages.google-cloud-audit-log: 0.1.1 -> 0.2.0`                          |
| [`3ae6ea79`](https://github.com/NixOS/nixpkgs/commit/3ae6ea79e21a5e2d9284321174fba22b8099e547) | `python38Packages.google-cloud-vision: 2.5.0 -> 2.6.1`                             |
| [`f8d38db8`](https://github.com/NixOS/nixpkgs/commit/f8d38db8d7c995e0e20ab6b4e48cac26c2ef0dfa) | `nvidia_x11 _legacy470: init at 470.74`                                            |
| [`a7ad7f05`](https://github.com/NixOS/nixpkgs/commit/a7ad7f05bd1f5578486165d67d047c48acdfeeeb) | `linuxPackages.bcc: 0.20.0 -> 0.22.0`                                              |